### PR TITLE
docs: section 05 cleanup + secret-scanning tooling (v0.3.0)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,28 @@
+# gitleaks configuration for awesome-foundry-nextgen
+#
+# Extends the default gitleaks rules (genuine secrets: API keys, tokens,
+# connection strings) with a repo-specific rule that catches Azure
+# subscription IDs leaked in URLs or resource paths - the main category of
+# environment identifier that turns up in committed notebook outputs.
+#
+# Enforced locally via the pre-commit hook (see .pre-commit-config.yaml), which
+# scans only staged changes. To scan the whole working tree manually:
+#   docker run --rm -v "$PWD:/repo" zricethezav/gitleaks:v8.30.1 dir /repo
+
+title = "awesome-foundry-nextgen"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "azure-subscription-id-in-path"
+description = "Azure subscription ID in a URL or resource path (likely leaked from a notebook output or portal deep link)"
+regex = '''(?i)subscription(?:s|id)[/=]([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})'''
+tags = ["azure", "subscription-id"]
+
+[allowlist]
+description = "Documented placeholder values that are safe to commit"
+regexes = [
+  # canonical all-zeros example subscription ID used throughout Azure docs
+  '''0{8}-0{4}-0{4}-0{4}-0{12}''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# Pre-commit hooks for awesome-foundry-nextgen.
+#
+# One-time setup per clone:
+#   pip install pre-commit   (or: uv tool install pre-commit)
+#   pre-commit install
+#
+# Run manually against everything already committed:
+#   pre-commit run --all-files
+#
+# The gitleaks hook scans only staged changes, so it blocks NEW secret or
+# identifier leaks without re-flagging un-scrubbed content elsewhere in the repo.
+# It uses the Docker image (Docker is the only prerequisite - no Go toolchain
+# needed) and the rules in .gitleaks.toml.
+#
+# See https://pre-commit.com and https://github.com/gitleaks/gitleaks
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks-docker

--- a/05-foundry-project-pattern-setup/05-00-project-setup.md
+++ b/05-foundry-project-pattern-setup/05-00-project-setup.md
@@ -1,9 +1,8 @@
-# Introduction
-Looking to leverage Microsoft Foundry for building out and managing your AI building blocks at scale will introduce you to some essential Azure infrastructure, provisioning patterns, and Role-Based Access Control models. 
+# Foundry project pattern setup
 
-The remainder of this page covers those concepts; the labs listed below put them into practice with Bicep templates and notebooks.
+Leveraging Microsoft Foundry to build and manage your AI building blocks at scale introduces some essential Azure infrastructure, provisioning patterns, and Role-Based Access Control models. This page covers those concepts; the labs listed below put them into practice with Bicep templates and notebooks.
 
-## Directory Contents
+## In this chapter
 
 | File | Description |
 |------|-------------|
@@ -14,7 +13,7 @@ The remainder of this page covers those concepts; the labs listed below put them
 
 ---
 
-## 1. Azure Management Hierarchy
+## Azure management hierarchy
 Azure organises resources into a four-level management hierarchy.
 
 ```
@@ -26,13 +25,13 @@ Management Groups
 
 **Management Groups** are optional containers that sit above subscriptions. They enable you to apply Azure Policy and RBAC across multiple subscriptions in a single operation. Enterprises typically create management groups aligned to business units, regulatory domains, or workload types. Example policies you could set at management level are denying public network access or use of API keys to access Foundry components. 
 
-**Subscriptions** serves three distinct purposes. They are your **billing boundary** (all charges in a subscription appear on a single invoice), your **management boundary** (subscription-level Azure Policy and RBAC apply to everything within it), and your **quota boundary** (Azure resource and service quotas like Tokens Per Minute are tracked per subscription per region).
+**Subscriptions** serve three distinct purposes. They are your **billing boundary** (all charges in a subscription appear on a single invoice), your **management boundary** (subscription-level Azure Policy and RBAC apply to everything within it), and your **quota boundary** (Azure resource and service quotas like Tokens Per Minute are tracked per subscription per region).
 
 **Resource Groups** are logical containers for deploying and managing related Azure resources as a lifecycle unit. For example resources can be deleted together. You can apply tags so that for example Azure Cost Management can filter for costs by tags. 
 
-**Resources** are the individual Azure services you provision — in the context of this guide, a Foundry resource or Foundry project.
+**Resources** are the individual Azure services you provision - in the context of this guide, a Foundry resource or Foundry project.
 
-## 2. Foundry Resource Architecture
+## Foundry resource architecture
 
 Microsoft Foundry uses a **two-level hierarchy**: 
 
@@ -42,20 +41,20 @@ Microsoft Foundry uses a **two-level hierarchy**:
 So Foundry resources are provisioned in your subscription and resource group, and carry all settings that govern all projects beneath it: networking configuration, RBAC assignments, Azure Policy applicability, and model deployment quotas.
 
 
-## 3. Foundry deployment patterns
+## Foundry deployment patterns
 
- Because a Foundry resource acts as both a cost boundary and a governance boundary, how you map resources to teams is one of the first architectural decisions you'll make — and it shapes isolation, compliance, and operational overhead for everything beneath it.
+ Because a Foundry resource acts as both a cost boundary and a governance boundary, how you map resources to teams is one of the first architectural decisions you'll make - and it shapes isolation, compliance, and operational overhead for everything beneath it.
 
 ### Why 1:N?
 
-You should consider the 1:N pattern, which means a single Foundry resource hosting multiple projects — one account, many teams.
+You should consider the 1:N pattern, which means a single Foundry resource hosting multiple projects - one account, many teams.
 
 In enterprise environments, teams within the same department share infrastructure costs while maintaining project-level isolation:
 
-Cost efficiency -- one AI account instead of N accounts
-Isolation -- each team has its own project workspace, agents, and data
-Shared RBAC -- account-level roles propagate; project-level roles scope access
-Unified management -- single account to monitor, patch, and govern
+- **Cost efficiency**: one AI account instead of N accounts
+- **Isolation**: each team has its own project workspace, agents, and data
+- **Shared RBAC**: account-level roles propagate; project-level roles scope access
+- **Unified management**: single account to monitor, patch, and govern
 
 You can create agents per project, as these are scoped to projects, not accounts.
 
@@ -69,32 +68,32 @@ You can create agents per project, as these are scoped to projects, not accounts
 | Rapid prototyping with many small teams | 1:N to avoid account sprawl |
 
 
-### What is Shared vs Isolated
+### What is shared vs isolated
 
 | Capability | Shared across projects | Isolated per project |
 |---|---|---|
-| Network configuration (VNet, private endpoints) | Yes — set at Foundry resource level | No |
-| Azure Policy assignments | Yes — inherited from Foundry resource | No |
-| Model deployments | Yes — deployed at resource level, accessible to all projects | No |
-| RBAC (resource-level assignments) | Yes — resource-level roles apply to all projects | No |
-| RBAC (project-level assignments) | No | Yes — project-scoped roles are isolated |
-| Connections (resource-scoped) | Yes — all projects can use them | No |
-| Connections (project-scoped) | No | Yes — visible only to the owning project |
+| Network configuration (VNet, private endpoints) | Yes - set at Foundry resource level | No |
+| Azure Policy assignments | Yes - inherited from Foundry resource | No |
+| Model deployments | Yes - deployed at resource level, accessible to all projects | No |
+| RBAC (resource-level assignments) | Yes - resource-level roles apply to all projects | No |
+| RBAC (project-level assignments) | No | Yes - project-scoped roles are isolated |
+| Connections (resource-scoped) | Yes - all projects can use them | No |
+| Connections (project-scoped) | No | Yes - visible only to the owning project |
 | Agent definitions | No | Yes |
 | Evaluation history | No | Yes |
-| Data storage (default managed) | No | Yes — Microsoft-managed logical separation per project |
+| Data storage (default managed) | No | Yes - Microsoft-managed logical separation per project |
 | Fine-tuned model deployments | No | Yes |
 
 
-### Example Permissions Setup
+### Example permissions setup
 
 Consider a small team with two admins and four developers getting started with Foundry on a new Azure subscription. The recommended approach is to create two Entra ID security groups and assign RBAC roles to the groups rather than to individual users. This reduces the number of role assignments consumed against the subscription limit and makes onboarding and offboarding straightforward.
 
-#### Entra ID Security Groups
+#### Entra ID security groups
 
 Create two **Security Groups** in Microsoft Entra ID. The key configuration requirements are:
 
-- Set **"Microsoft Entra roles can be assigned to the group"** to **Yes** at creation time — this property is immutable and cannot be changed after the group is created.
+- Set **"Microsoft Entra roles can be assigned to the group"** to **Yes** at creation time - this property is immutable and cannot be changed after the group is created.
 - Use **Assigned** membership type (not Dynamic) to prevent unintended privilege escalation.
 
 | Group | Members |
@@ -102,47 +101,49 @@ Create two **Security Groups** in Microsoft Entra ID. The key configuration requ
 | `grp-foundry-admins` | Admin 1, Admin 2 |
 | `grp-foundry-developers` | Dev 1, Dev 2, Dev 3, Dev 4 |
 
-#### The Two-Layer Permission Model
+#### The two-layer permission model
 
 Foundry access requires two independent IAM layers that must each be configured separately:
 
 | Layer | Where assigned | Controls |
 |---|---|---|
-| **Layer 1 — Foundry plane** | Foundry resource or Project > Access Control (IAM) | Portal access, project creation, agent building, model deployment |
-| **Layer 2 — Cognitive Services plane** | Azure AI Services resource > Access Control (IAM) | Content safety filters/guardrails, quota management, API key access |
+| **Layer 1 - Foundry plane** | Foundry resource or Project > Access Control (IAM) | Portal access, project creation, agent building, model deployment |
+| **Layer 2 - Cognitive Services plane** | Azure AI Services resource > Access Control (IAM) | Content safety filters/guardrails, quota management, API key access |
 
-The Foundry portal Users blade only handles Layer 1. Layer 2 must be configured directly on the underlying Azure AI Services resource — this step is commonly missed.
+The Foundry portal Users blade only handles Layer 1. Layer 2 must be configured directly on the underlying Azure AI Services resource - this step is commonly missed.
 
-#### Layer 1 — Foundry-Specific Built-in Roles
+#### Layer 1: Foundry-specific built-in roles
 
 The four Foundry-specific built-in roles have asymmetric permission coverage across the control plane (ARM actions) and data plane (dataActions). Understanding this split is essential:
 
 | Role | Control plane | Data plane | Key capabilities |
 |---|---|---|---|
-| **Azure AI User** | Read-only | Full (`Microsoft.CognitiveServices/*`) | Build agents, call APIs, run prompts, use deployed models |
-| **Azure AI Project Manager** | `accounts/projects/*` write + read | Full (`Microsoft.CognitiveServices/*`) | Everything AI User can do, plus create projects and register MCP server connections |
-| **Azure AI Account Owner** | Full (`Microsoft.CognitiveServices/*`) | **None** | Deploy models, create projects, manage connections — but cannot build or develop |
-| **Azure AI Owner** | Full | Full | Unrestricted; combines all capabilities of the above |
+| **Foundry User** | Read-only | Full (`Microsoft.CognitiveServices/*`) | Build agents, call APIs, run prompts, use deployed models |
+| **Foundry Project Manager** | `accounts/projects/*` write + read | Full (`Microsoft.CognitiveServices/*`) | Everything AI User can do, plus create projects and register MCP server connections |
+| **Foundry Account Owner** | Full (`Microsoft.CognitiveServices/*`) | **None** | Deploy models, create projects, manage connections - but cannot build or develop |
+| **Foundry Owner** | Full | Full | Unrestricted; combines all capabilities of the above |
+
+> **Note:** These roles were recently renamed from `Azure AI User`, `Azure AI Owner`, `Azure AI Account Owner`, and `Azure AI Project Manager`. Role IDs and permissions are unchanged. See [Built-in Foundry roles](../04-foundry-control-plane/04-01-foundry-enterprise-provisioning.md#built-in-foundry-roles) for the full definitions.
 
 Roles assigned at the **Foundry resource (account) level** cascade down to all projects within it. Roles assigned at the **project level** are scoped to that project only.
 
-#### Layer 2 — Cognitive Services Roles
+#### Layer 2: Cognitive Services roles
 
 | Role | Assigned to | Deploy models | Content filters | View quota | Edit quota |
 |---|---|---|---|---|---|
 | **Cognitive Services Contributor** | `grp-foundry-admins` | Yes | **Yes** | Yes | Yes |
 | **Cognitive Services OpenAI Contributor** | `grp-foundry-developers` | Yes (OpenAI models) | No | No | No |
-| **Cognitive Services Usages Reader** | `grp-foundry-admins` | — | — | Yes | Yes |
+| **Cognitive Services Usages Reader** | `grp-foundry-admins` | - | - | Yes | Yes |
 
-> **Note:** `Cognitive Services Usages Reader` must be assigned at **subscription scope** — it has no effect if assigned at the resource group or resource level.
+> **Note:** `Cognitive Services Usages Reader` must be assigned at **subscription scope** - it has no effect if assigned at the resource group or resource level.
 
-#### Role Assignments Summary
+#### Role assignments summary
 
 **`grp-foundry-admins`**
 
 | Role | Scope | Justification |
 |---|---|---|
-| Azure AI Account Owner | Foundry resource | Deploy models, create projects, manage connections |
+| Foundry Account Owner | Foundry resource | Deploy models, create projects, manage connections |
 | Cognitive Services Contributor | AI Services resource | Create and edit content safety filters/guardrails |
 | Cognitive Services Usages Reader | Subscription | View and edit model quota in Management Center |
 
@@ -152,24 +153,28 @@ If developers only need to build agents and use existing connections (admins han
 
 | Role | Scope | Justification |
 |---|---|---|
-| Azure AI User | Foundry resource | Full data-plane access across all projects |
+| Foundry User | Foundry resource | Full data-plane access across all projects |
 | Cognitive Services OpenAI Contributor | AI Services resource | Create model deployments |
 
-If developers also need to register remote MCP servers themselves, replace `Azure AI User` with `Azure AI Project Manager`, which adds control-plane write access to project resources (connections) while retaining full data-plane access.
+If developers also need to register remote MCP servers themselves, replace `Foundry User` with `Foundry Project Manager`, which adds control-plane write access to project resources (connections) while retaining full data-plane access.
 
-#### Verified Permission Mapping
+#### Verified permission mapping
 
 The following table maps specific Foundry operations to the minimum required role, sourced from Microsoft's official documentation:
 
 | Operation | Minimum role | Plane | Scope | Source |
 |---|---|---|---|---|
-| Deploy a model | Azure AI Account Owner or Cognitive Services Contributor | Control | Foundry resource | [Create model deployments](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/how-to/create-model-deployments) |
-| Create an agent | Azure AI User | Data | Foundry project | [Agent Service environment setup](https://learn.microsoft.com/en-us/azure/ai-foundry/agents/environment-setup) |
-| Create a new project | Azure AI Project Manager or Azure AI Account Owner | Control | Foundry resource | [RBAC for Microsoft Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/rbac-foundry) |
-| Register a remote MCP server | Azure AI Project Manager or Contributor (at project scope) | Control | Foundry project | [Connect to MCP Server Endpoints](https://learn.microsoft.com/en-us/azure/ai-foundry/agents/how-to/tools/model-context-protocol) |
-| Use an MCP tool in an agent | Azure AI User | Data | Foundry project | [MCP server authentication](https://learn.microsoft.com/en-us/azure/ai-foundry/agents/how-to/mcp-authentication) |
+| Deploy a model | Foundry Account Owner or Cognitive Services Contributor | Control | Foundry resource | [Create model deployments](https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/how-to/create-model-deployments) |
+| Create an agent | Foundry User | Data | Foundry project | [Agent Service environment setup](https://learn.microsoft.com/en-us/azure/ai-foundry/agents/environment-setup) |
+| Create a new project | Foundry Project Manager or Foundry Account Owner | Control | Foundry resource | [RBAC for Microsoft Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/rbac-foundry) |
+| Register a remote MCP server | Foundry Project Manager or Contributor (at project scope) | Control | Foundry project | [Connect to MCP Server Endpoints](https://learn.microsoft.com/en-us/azure/ai-foundry/agents/how-to/tools/model-context-protocol) |
+| Use an MCP tool in an agent | Foundry User | Data | Foundry project | [MCP server authentication](https://learn.microsoft.com/en-us/azure/ai-foundry/agents/how-to/mcp-authentication) |
 | Create/edit content safety filters | Cognitive Services Contributor | Control | AI Services resource | [Azure OpenAI RBAC](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/role-based-access-control) |
 | View and edit quota limits | Cognitive Services Usages Reader | Control | Subscription | [Azure OpenAI RBAC](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/role-based-access-control) |
-| View admin overview / Management Center | Azure AI Account Owner + Cognitive Services Usages Reader | Both | Resource + Subscription | [RBAC for Microsoft Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/rbac-foundry) |
+| View admin overview / Management Center | Foundry Account Owner + Cognitive Services Usages Reader | Both | Resource + Subscription | [RBAC for Microsoft Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/concepts/rbac-foundry) |
 
-> **Important:** `Azure AI Account Owner` has zero data-plane actions in its role definition. An admin assigned only this role cannot create agents or build within a project. If an admin needs to develop as well as manage, they should also be assigned `Azure AI User` on the relevant project, or use `Azure AI Owner` instead.
+> **Important:** `Foundry Account Owner` has zero data-plane actions in its role definition. An admin assigned only this role cannot create agents or build within a project. If an admin needs to develop as well as manage, they should also be assigned `Foundry User` on the relevant project, or use `Foundry Owner` instead.
+
+---
+
+[Next: Architecture →](05-01-architecture.md)

--- a/05-foundry-project-pattern-setup/05-01-architecture.md
+++ b/05-foundry-project-pattern-setup/05-01-architecture.md
@@ -1,4 +1,4 @@
-# Lab 1 Architecture: Core Gateway with Team Projects
+# Architecture
 
 ## Overview
 
@@ -6,43 +6,43 @@ The Lab 1 series deploys a **centralised AI gateway pattern**: a single API Mana
 
 Two Foundry provisioning patterns are demonstrated side-by-side:
 
-- **1:1 Spoke** (Lab 1B) — Team Alpha has its own dedicated Foundry account, giving it a hard infrastructure boundary. This suits teams with strict compliance or cost isolation requirements.
-- **1:N Multi-Project** (Lab 1C) — Teams Beta, Delta, and Gamma share a single Foundry account with project-level isolation. This is the preferred pattern for teams in the same department or cost centre.
+- **1:1 Spoke** (Lab 1B) - Team Alpha has its own dedicated Foundry account, giving it a hard infrastructure boundary. This suits teams with strict compliance or cost isolation requirements.
+- **1:N Multi-Project** (Lab 1C) - Teams Beta, Delta, and Gamma share a single Foundry account with project-level isolation. This is the preferred pattern for teams in the same department or cost centre.
 
-Neither pattern changes how teams reach the gateway or which models they can use — that is determined entirely by their project connection and APIM subscription.
+Neither pattern changes how teams reach the gateway or which models they can use - that is determined entirely by their project connection and APIM subscription.
 
 ---
 
-## Component Inventory
+## Component inventory
 
-> **Resource name suffix:** Resource names below include `{suffix}` — first 6 characters of `sha256(subscription_id + 'v2')`, computed by the lab notebooks and passed as a parameter to every Bicep template. Stable for a given subscription; bump the `'v2'` salt to force a clean redeploy under new names.
+> **Resource name suffix:** Resource names below include `{suffix}` - first 6 characters of `sha256(subscription_id + 'v2')`, computed by the lab notebooks and passed as a parameter to every Bicep template. Stable for a given subscription; bump the `'v2'` salt to force a clean redeploy under new names.
 
-> **Team naming convention:** Greek letters (Alpha, Beta, Delta, Gamma) are used exclusively as **team identifiers** — they denote application teams, not capabilities or workloads. Capability-specific resources take a descriptive qualifier instead (e.g. `hosted`, `memory`) rather than a new Greek letter. A new Greek name would imply a new team exists, which would be misleading. The APIM connection on a team's project always follows `core-{team}` (e.g. `core-alpha`).
+> **Team naming convention:** Greek letters (Alpha, Beta, Delta, Gamma) are used exclusively as **team identifiers** - they denote application teams, not capabilities or workloads. Capability-specific resources take a descriptive qualifier instead (e.g. `hosted`, `memory`) rather than a new Greek letter. A new Greek name would imply a new team exists, which would be misleading. The APIM connection on a team's project always follows `core-{team}` (e.g. `core-alpha`).
 
-### Landing Zone — `rg-foundry-core-{suffix}`
+### Landing zone: `rg-foundry-core-{suffix}`
 
 The shared infrastructure backbone. All team projects route model requests through this resource group.
 
 | Resource | Type | Region | `.env` key | Purpose |
 |----------|------|--------|------------|---------|
-| `apim-foundry-{suffix}` | API Management BasicV2 | East US 2 | `GATEWAY_URL` | Central gateway — single URL for all model access |
+| `apim-foundry-{suffix}` | API Management BasicV2 | East US 2 | `GATEWAY_URL` | Central gateway - single URL for all model access |
 | `aif-core-{suffix}` | Foundry Account (AI Services) | East US 2 | `CORE_ENDPOINT` | Primary core: general purpose and routing models |
 | `project-admin-{suffix}` | Foundry Project (child of `aif-core`) | East US 2 | `ADMIN_FOUNDRY_PROJECT_ENDPOINT` | Admin project: hosts centrally-managed agents, evaluations, observability, and load-gen workloads (08-05, 08-06, 08-07, 20-*) |
-| `aif-research-{suffix}` | Foundry Account (AI Services) | Norway East | — | Research hub: advanced reasoning models |
-| `aif-oss-{suffix}` | Foundry Account (AI Services) | West US 3 | — | OSS hub: open-weights models |
-| `stfoundry{suffix}` | Storage Account | East US 2 | — | Shared storage |
+| `aif-research-{suffix}` | Foundry Account (AI Services) | Norway East | - | Research hub: advanced reasoning models |
+| `aif-oss-{suffix}` | Foundry Account (AI Services) | West US 3 | - | OSS hub: open-weights models |
+| `stfoundry{suffix}` | Storage Account | East US 2 | - | Shared storage |
 
 > [!IMPORTANT]
 > **APIM SKU and private Foundry resources**
 >
-> The Foundry AI Gateway feature requires APIM in a v2 tier — **BasicV2**, **StandardV2**, or **PremiumV2**. BasicV2 is used here as the cost-effective option for public Foundry resources.
+> The Foundry AI Gateway feature requires APIM in a v2 tier - **BasicV2**, **StandardV2**, or **PremiumV2**. BasicV2 is used here as the cost-effective option for public Foundry resources.
 >
 > **If the Foundry resource has public network access disabled, BasicV2 is not sufficient.** BasicV2 does not support private endpoints, so APIM cannot reach a private Foundry resource. In that case, switch to:
 >
 > - **StandardV2** or **PremiumV2** with a private endpoint, or
 > - **PremiumV2** injected into a virtual network.
 >
-> Microsoft Learn quote — [Configure AI Gateway in your Foundry resources](https://learn.microsoft.com/en-us/azure/foundry/configuration/enable-ai-api-management-gateway-portal):
+> Microsoft Learn quote - [Configure AI Gateway in your Foundry resources](https://learn.microsoft.com/en-us/azure/foundry/configuration/enable-ai-api-management-gateway-portal):
 >
 > > "If your Foundry resource has public network access disabled, make sure that your API Management instance is also privately accessible to integrate with your private Foundry resource. In this case, use a Standard v2 or Premium v2 instance with a private endpoint, or a Premium v2 instance that's injected in a virtual network."
 
@@ -55,7 +55,7 @@ The shared infrastructure backbone. All team projects route model requests throu
 | `o3-deep-research` | `aif-research-{suffix}` | Norway East | GlobalStandard 10K TPM | `RESEARCH_MODEL` | Advanced reasoning and deep research |
 | `Phi-4` | `aif-oss-{suffix}` | West US 3 | GlobalStandard 1K TPM | `OSS_MODEL` | Open-weights model from Microsoft |
 
-**APIM routing rules** (evaluated in order — specific URL patterns win over the default):
+**APIM routing rules** (evaluated in order - specific URL patterns win over the default):
 
 | Rule | URL pattern | Backend | Auth |
 |------|------------|---------|------|
@@ -71,16 +71,16 @@ The shared infrastructure backbone. All team projects route model requests throu
 | `foundry-gateway-beta` | `openai` API | `BETA_GATEWAY_KEY` | Team Beta |
 | `foundry-gateway-delta` | `openai` API | `DELTA_GATEWAY_KEY` | Team Delta |
 | `foundry-gateway-gamma` | `openai` API | `GAMMA_GATEWAY_KEY` | Team Gamma |
-| `foundry-gateway-iq` | `openai` API | `IQ_GATEWAY_KEY` | Lab 10 Foundry IQ — isolated from team quotas; the embedding batch ingest for 3,000 documents generates ~6M tokens and must not compete with team traffic |
-| `foundry-gateway-contoso-pmo` | `openai` API | `CONTOSO_PMO_GATEWAY_KEY` | Lab 08-05 Contoso PMO KB — dedicated MCP server workload; avoids competing with team inference traffic |
-| `foundry-gateway-cu` | `openai` API | `CU_GATEWAY_KEY` | Lab 10 Content Understanding — dedicated CU workload quota; also gates access to the `/cu` APIM API |
-| `foundry-gateway-obs` | `openai` API | `OBS_GATEWAY_KEY` | Lab 07-05 Agent Observability — dedicated APIM subscription isolates tracing workload quota from team traffic |
+| `foundry-gateway-iq` | `openai` API | `IQ_GATEWAY_KEY` | Lab 10 Foundry IQ - isolated from team quotas; the embedding batch ingest for 3,000 documents generates ~6M tokens and must not compete with team traffic |
+| `foundry-gateway-contoso-pmo` | `openai` API | `CONTOSO_PMO_GATEWAY_KEY` | Lab 08-05 Contoso PMO KB - dedicated MCP server workload; avoids competing with team inference traffic |
+| `foundry-gateway-cu` | `openai` API | `CU_GATEWAY_KEY` | Lab 10 Content Understanding - dedicated CU workload quota; also gates access to the `/cu` APIM API |
+| `foundry-gateway-obs` | `openai` API | `OBS_GATEWAY_KEY` | Lab 07-05 Agent Observability - dedicated APIM subscription isolates tracing workload quota from team traffic |
 
 ---
 
-### Team Alpha Spoke — `rg-foundry-spoke-alpha-{suffix}` (1:1 pattern)
+### Team Alpha spoke: `rg-foundry-spoke-alpha-{suffix}` (1:1 pattern)
 
-Team Alpha has a dedicated Foundry account with no local model deployments — all inference is handled by the core gateway.
+Team Alpha has a dedicated Foundry account with no local model deployments - all inference is handled by the core gateway.
 
 | Resource | Type | Region | `.env` keys |
 |----------|------|--------|-------------|
@@ -93,23 +93,23 @@ Model access via connection: `core-alpha/gpt-4.1-mini`
 
 ---
 
-### Teams Beta, Delta, Gamma + Lab 09 Foundry IQ Multi-Agent + Lab 10 Foundry IQ + Lab 08-05 Contoso PMO KB + Lab 07-05 Observability — `rg-foundry-multi-{suffix}` (1:N pattern)
+### Teams Beta, Delta, Gamma + Lab 09 Foundry IQ Multi-Agent + Lab 10 Foundry IQ + Lab 08-05 Contoso PMO KB + Lab 07-05 Observability: `rg-foundry-multi-{suffix}` (1:N pattern)
 
-Three teams share one Foundry account (`aif-spoke-multi-{suffix}`). Project-level isolation ensures each team's agents and data remain separate. Lab 09 (Foundry IQ Multi-Agent) extends this account with a `contoso-project` and a dedicated Standard SKU Azure AI Search service; Lab 10 (Foundry IQ) extends this account with a fourth project (`iq-project`) and a dedicated Azure AI Search service; Lab 08-05 (Contoso PMO KB) adds a fifth project (`contoso-pmo-project`) for the custom MCP server workload; Lab 07-05 (Agent Observability) adds a sixth project (`obs-project`) with Application Insights — all demonstrating the 1:N pattern absorbing successive capability workloads without creating new Foundry accounts.
+Three teams share one Foundry account (`aif-spoke-multi-{suffix}`). Project-level isolation ensures each team's agents and data remain separate. Lab 09 (Foundry IQ Multi-Agent) extends this account with a `contoso-project` and a dedicated Standard SKU Azure AI Search service; Lab 10 (Foundry IQ) extends this account with a fourth project (`iq-project`) and a dedicated Azure AI Search service; Lab 08-05 (Contoso PMO KB) adds a fifth project (`contoso-pmo-project`) for the custom MCP server workload; Lab 07-05 (Agent Observability) adds a sixth project (`obs-project`) with Application Insights - all demonstrating the 1:N pattern absorbing successive capability workloads without creating new Foundry accounts.
 
 | Resource | Type | `.env` keys | Added by |
 |----------|------|-------------|----------|
 | `aif-spoke-multi-{suffix}` | Foundry Account (shared) | `MULTI_ACCOUNT`, `MULTI_ACCOUNT_ENDPOINT` | Lab 1C |
-| `project-beta-{suffix}` | Foundry Project — Team Beta | `BETA_FOUNDRY_PROJECT`, `BETA_FOUNDRY_PROJECT_ENDPOINT` | Lab 1C |
-| `project-delta-{suffix}` | Foundry Project — Team Delta | `DELTA_FOUNDRY_PROJECT`, `DELTA_FOUNDRY_PROJECT_ENDPOINT` | Lab 1C |
-| `project-gamma-{suffix}` | Foundry Project — Team Gamma | `GAMMA_FOUNDRY_PROJECT`, `GAMMA_FOUNDRY_PROJECT_ENDPOINT` | Lab 1C |
-| `contoso-project` | Foundry Project — Lab 09 Foundry IQ Multi-Agent | `CONTOSO_FOUNDRY_PROJECT`, `CONTOSO_FOUNDRY_PROJECT_ENDPOINT` | Lab 09 |
+| `project-beta-{suffix}` | Foundry Project - Team Beta | `BETA_FOUNDRY_PROJECT`, `BETA_FOUNDRY_PROJECT_ENDPOINT` | Lab 1C |
+| `project-delta-{suffix}` | Foundry Project - Team Delta | `DELTA_FOUNDRY_PROJECT`, `DELTA_FOUNDRY_PROJECT_ENDPOINT` | Lab 1C |
+| `project-gamma-{suffix}` | Foundry Project - Team Gamma | `GAMMA_FOUNDRY_PROJECT`, `GAMMA_FOUNDRY_PROJECT_ENDPOINT` | Lab 1C |
+| `contoso-project` | Foundry Project - Lab 09 Foundry IQ Multi-Agent | `CONTOSO_FOUNDRY_PROJECT`, `CONTOSO_FOUNDRY_PROJECT_ENDPOINT` | Lab 09 |
 | `contoso-search-{suffix}` | Azure AI Search (Standard, SystemAssigned identity) | `CONTOSO_SEARCH_ENDPOINT`, `CONTOSO_SEARCH_NAME` | Lab 09 |
-| `iq-project` | Foundry Project — Lab 10 Foundry IQ | `IQ_FOUNDRY_PROJECT`, `IQ_FOUNDRY_PROJECT_ENDPOINT` | Lab 10 |
-| `contoso-pmo-project` | Foundry Project — Lab 08-05 Contoso PMO KB | `CONTOSO_PMO_FOUNDRY_PROJECT`, `CONTOSO_PMO_FOUNDRY_PROJECT_ENDPOINT` | Lab 08-05 |
+| `iq-project` | Foundry Project - Lab 10 Foundry IQ | `IQ_FOUNDRY_PROJECT`, `IQ_FOUNDRY_PROJECT_ENDPOINT` | Lab 10 |
+| `contoso-pmo-project` | Foundry Project - Lab 08-05 Contoso PMO KB | `CONTOSO_PMO_FOUNDRY_PROJECT`, `CONTOSO_PMO_FOUNDRY_PROJECT_ENDPOINT` | Lab 08-05 |
 | `iq-search-{suffix}` | Azure AI Search (Basic, SystemAssigned identity) | `IQ_SEARCH_ENDPOINT`, `IQ_SEARCH_NAME` | Lab 10 |
-| `obs-project` | Foundry Project — Lab 07-05 Agent Observability | `OBS_FOUNDRY_PROJECT_ENDPOINT` | Lab 07-05 |
-| `log-obs-{suffix}` | Log Analytics Workspace | — | Lab 07-05 |
+| `obs-project` | Foundry Project - Lab 07-05 Agent Observability | `OBS_FOUNDRY_PROJECT_ENDPOINT` | Lab 07-05 |
+| `log-obs-{suffix}` | Log Analytics Workspace | - | Lab 07-05 |
 | `appi-obs-{suffix}` | Application Insights | `OBS_APP_INSIGHTS_NAME`, `OBS_APP_INSIGHTS_CONN_STRING` | Lab 07-05 |
 
 Each project connects to the gateway via its own named APIM connection and key:
@@ -124,9 +124,9 @@ Each project connects to the gateway via its own named APIM connection and key:
 | `obs-project` | `landing-zone-apim` | `OBS_APIM_CONNECTION` | `OBS_GATEWAY_KEY` |
 | `cu-project` | `landing-zone-apim` | `CU_APIM_CONNECTION` | `CU_GATEWAY_KEY` |
 
-> **Connection naming**: team core connections follow `core-{team}` (e.g. `core-beta`). The `iq-project`, `contoso-pmo-project`, and `obs-project` connections are named `landing-zone-apim` because `iq`, `contoso-pmo`, and `obs` are capability qualifiers, not team names — all three use descriptive connection names that reflect what they are connecting to.
+> **Connection naming**: team core connections follow `core-{team}` (e.g. `core-beta`). The `iq-project`, `contoso-pmo-project`, and `obs-project` connections are named `landing-zone-apim` because `iq`, `contoso-pmo`, and `obs` are capability qualifiers, not team names - all three use descriptive connection names that reflect what they are connecting to.
 
-**`iq-search-{suffix}` — Azure AI Search index details (Lab 10):**
+**`iq-search-{suffix}` - Azure AI Search index details (Lab 10):**
 
 | Index | Dimensions | Algorithm | Semantic config | KB |
 |-------|-----------|-----------|----------------|----|
@@ -136,9 +136,9 @@ The search service's managed identity is granted **Cognitive Services User** on 
 
 ---
 
-### Lab 10 Content Understanding — `rg-foundry-cu-{suffix}`
+### Lab 10 Content Understanding: `rg-foundry-cu-{suffix}`
 
-Content Understanding requires a **dedicated** AI Services account with local model deployments — it cannot share `aif-spoke-multi-{suffix}`, which has the `deny-model-deployments` policy assigned. A new resource group (`rg-foundry-cu-{suffix}`) is created exclusively for this lab.
+Content Understanding requires a **dedicated** AI Services account with local model deployments - it cannot share `aif-spoke-multi-{suffix}`, which has the `deny-model-deployments` policy assigned. A new resource group (`rg-foundry-cu-{suffix}`) is created exclusively for this lab.
 
 | Resource | Type | Region | `.env` keys |
 |----------|------|--------|-------------|
@@ -149,17 +149,17 @@ Content Understanding requires a **dedicated** AI Services account with local mo
 
 Connection: `cu-project` → `landing-zone-apim` (`CU_APIM_CONNECTION`) with key `CU_GATEWAY_KEY`
 
-> **Policy exemption**: `rg-foundry-cu-{suffix}` is explicitly **excluded** from the `deny-model-deployments` policy — local model deployments are intentional and required for CU field extraction analyzers. `cu` is a capability qualifier, not a team name.
+> **Policy exemption**: `rg-foundry-cu-{suffix}` is explicitly **excluded** from the `deny-model-deployments` policy - local model deployments are intentional and required for CU field extraction analyzers. `cu` is a capability qualifier, not a team name.
 
 ---
 
-## APIM Routing
+## APIM routing
 
 All model traffic enters through the single APIM gateway (`apim-foundry-{suffix}`). APIM decides which Foundry core account to forward each request to based on **URL pattern matching**: the incoming request path is compared against the `urlTemplate` of each operation defined on the `openai` API, and the most specific match wins.
 
 ### How matching works
 
-APIM evaluates operations in specificity order — an exact literal path beats a wildcard path. The `{deployment-id}` placeholder in a `urlTemplate` is a wildcard; a literal model name in the same position is an exact match and always takes priority.
+APIM evaluates operations in specificity order - an exact literal path beats a wildcard path. The `{deployment-id}` placeholder in a `urlTemplate` is a wildcard; a literal model name in the same position is an exact match and always takes priority.
 
 ```
 POST /deployments/o3-deep-research/chat/completions
@@ -186,11 +186,11 @@ Operations that have **no operation-level policy** inherit the **API-level (All 
 |---|---|---|---|
 | `chat-research` | Chat Completions (Research) | Yes | `set-backend-service backend-id="openai-research"` + managed identity auth |
 | `chat-oss` | Chat Completions (OSS) | Yes | `set-backend-service backend-id="openai-oss"` + managed identity auth |
-| `chat` | Chat Completions | No — inherits API-level | API-level: `set-backend-service backend-id="openai"` + managed identity auth + rate limit (100/60s) + default `api-version=2024-10-21` |
-| `embeddings` | Embeddings | No — inherits API-level | same as above |
-| `responses` | Responses | No — inherits API-level | same as above |
+| `chat` | Chat Completions | No - inherits API-level | API-level: `set-backend-service backend-id="openai"` + managed identity auth + rate limit (100/60s) + default `api-version=2024-10-21` |
+| `embeddings` | Embeddings | No - inherits API-level | same as above |
+| `responses` | Responses | No - inherits API-level | same as above |
 
-> **Policy naming note:** every APIM policy resource has the name `policy` — it is not a meaningful identifier. What distinguishes policies is which operation (or API) they are attached to. Operations with no policy of their own fall through to the API-level policy attached to "All operations".
+> **Policy naming note:** every APIM policy resource has the name `policy` - it is not a meaningful identifier. What distinguishes policies is which operation (or API) they are attached to. Operations with no policy of their own fall through to the API-level policy attached to "All operations".
 
 ### Operation → backend → Foundry account → model
 
@@ -208,15 +208,15 @@ Each backend resource stores the target Foundry account endpoint. APIM substitut
 
 | Backend ID | Target URL | Foundry account |
 |---|---|---|
-| `openai` | `${aif-core-{suffix}.endpoint}openai` | `aif-core-{suffix}` — primary core (East US 2) |
-| `openai-research` | `${aif-research-{suffix}.endpoint}openai` | `aif-research-{suffix}` — research hub (Norway East) |
-| `openai-oss` | `${aif-oss-{suffix}.endpoint}openai` | `aif-oss-{suffix}` — OSS hub (West US 3) |
+| `openai` | `${aif-core-{suffix}.endpoint}openai` | `aif-core-{suffix}` - primary core (East US 2) |
+| `openai-research` | `${aif-research-{suffix}.endpoint}openai` | `aif-research-{suffix}` - research hub (Norway East) |
+| `openai-oss` | `${aif-oss-{suffix}.endpoint}openai` | `aif-oss-{suffix}` - OSS hub (West US 3) |
 
 ### Request flow walkthrough
 
-The path suffix passes through APIM **unchanged** — APIM only swaps the host and injects auth. The model name is already encoded in the URL, so the Foundry account knows which deployment to invoke without any further transformation.
+The path suffix passes through APIM **unchanged** - APIM only swaps the host and injects auth. The model name is already encoded in the URL, so the Foundry account knows which deployment to invoke without any further transformation.
 
-Example — research model request:
+Example - research model request:
 
 ```
 Client
@@ -230,17 +230,17 @@ Client
   → o3-deep-research model responds
 ```
 
-The same mechanics apply to the default backend — for `gpt-4.1-mini` the path `/deployments/gpt-4.1-mini/chat/completions` passes through untouched, with only the host replaced by `aif-core-{suffix}.cognitiveservices.azure.com`.
+The same mechanics apply to the default backend - for `gpt-4.1-mini` the path `/deployments/gpt-4.1-mini/chat/completions` passes through untouched, with only the host replaced by `aif-core-{suffix}.cognitiveservices.azure.com`.
 
 ### Authentication
 
-In all cases APIM replaces the client's APIM subscription key with a **managed identity Bearer token** before forwarding to the Foundry account. The `authentication-managed-identity` policy element acquires a token scoped to `https://cognitiveservices.azure.com` and injects it as an `Authorization: Bearer …` header. Key-based access is disabled on all hub accounts by Azure policy — only APIM's managed identity can call them.
+In all cases APIM replaces the client's APIM subscription key with a **managed identity Bearer token** before forwarding to the Foundry account. The `authentication-managed-identity` policy element acquires a token scoped to `https://cognitiveservices.azure.com` and injects it as an `Authorization: Bearer …` header. Key-based access is disabled on all hub accounts by Azure policy - only APIM's managed identity can call them.
 
 The Bicep grants APIM's system-assigned identity the **Cognitive Services User** role on all three hub accounts (`aif-core`, `aif-research`, `aif-oss`) so it can acquire valid tokens for each backend.
 
 ---
 
-## Governance and Workload Placement Constraints
+## Governance and workload placement constraints
 
 ### Deny policy: no model deployments in spoke resource groups
 
@@ -248,25 +248,25 @@ A subscription-level Azure Policy definition (`deny-model-deployments`) is assig
 
 | Resource group | Policy assignment | Effect |
 |---|---|---|
-| `rg-foundry-core-{suffix}` | None — excluded by design | `Microsoft.CognitiveServices/accounts/deployments` allowed |
+| `rg-foundry-core-{suffix}` | None - excluded by design | `Microsoft.CognitiveServices/accounts/deployments` allowed |
 | `rg-foundry-spoke-alpha-{suffix}` | `deny-model-deployments-rg-foundry-spoke-alpha-{suffix}` | Denied |
 | `rg-foundry-multi-{suffix}` | `deny-model-deployments-rg-foundry-multi-{suffix}` | Denied |
 
-The policy rule matches resource type `Microsoft.CognitiveServices/accounts/deployments` and applies effect `deny`. Any attempt to create a model deployment inside a spoke resource group — including via Bicep, CLI, or portal — will fail with `RequestDisallowedByPolicy`. This enforces the architectural constraint that all model deployments live in the core.
+The policy rule matches resource type `Microsoft.CognitiveServices/accounts/deployments` and applies effect `deny`. Any attempt to create a model deployment inside a spoke resource group - including via Bicep, CLI, or portal - will fail with `RequestDisallowedByPolicy`. This enforces the architectural constraint that all model deployments live in the core.
 
-Any new resource group that hosts local model deployments (e.g. `rg-foundry-memory-{suffix}` for the Memory API lab) must be explicitly omitted from the policy assignment. It must **not** be assigned the deny policy, as local deployments are intentional in those resource groups. See `06-governance-policy/deploy-governance-policy.ipynb`.
+Any new resource group that hosts local model deployments (e.g. `rg-foundry-memory-{suffix}` for the Memory API lab) must be explicitly omitted from the policy assignment. It must **not** be assigned the deny policy, as local deployments are intentional in those resource groups. See `06-governance-policy/06-01-deploy-governance-policy.ipynb`.
 
 ### Why the hub must not host team workloads
 
-The APIM + hub Foundry account pattern is shared platform infrastructure. Team-level workloads — agents, memory stores, or any resource tied to a specific team's lifecycle — must never be placed on hub accounts or in `rg-foundry-core-{suffix}`. Three constraints enforce this:
+The APIM + hub Foundry account pattern is shared platform infrastructure. Team-level workloads - agents, memory stores, or any resource tied to a specific team's lifecycle - must never be placed on hub accounts or in `rg-foundry-core-{suffix}`. Three constraints enforce this:
 
 **1. Quota contention**
 
-The hub's `gpt-4.1-mini` deployment is provisioned at 30K TPM GlobalStandard, shared across all four teams via APIM. There is no mechanism to ring-fence a portion of that quota for a specific workload. Any team workload that places additional calls against core model deployments — for example, the Memory API's per-turn summarisation and fact-extraction calls, or embedding lookups — competes silently with all other inference traffic on the same quota pool. A single team's memory workload can starve the other three teams' APIM-routed requests.
+The hub's `gpt-4.1-mini` deployment is provisioned at 30K TPM GlobalStandard, shared across all four teams via APIM. There is no mechanism to ring-fence a portion of that quota for a specific workload. Any team workload that places additional calls against core model deployments - for example, the Memory API's per-turn summarisation and fact-extraction calls, or embedding lookups - competes silently with all other inference traffic on the same quota pool. A single team's memory workload can starve the other three teams' APIM-routed requests.
 
 **2. Hub ownership and blast radius**
 
-`rg-foundry-core-{suffix}` is owned by the platform/ops team. Application teams have no write access to it by design. Placing a team-level workload on the hub conflates infrastructure ownership with team workload ownership: if Team Alpha's memory agent misbehaves, generates runaway costs, or simply needs to be decommissioned, the remediation requires operating inside the shared core resource group — affecting all teams. Team workloads must be scoped to team-owned resource groups where the team can manage their own lifecycle independently.
+`rg-foundry-core-{suffix}` is owned by the platform/ops team. Application teams have no write access to it by design. Placing a team-level workload on the hub conflates infrastructure ownership with team workload ownership: if Team Alpha's memory agent misbehaves, generates runaway costs, or simply needs to be decommissioned, the remediation requires operating inside the shared core resource group - affecting all teams. Team workloads must be scoped to team-owned resource groups where the team can manage their own lifecycle independently.
 
 **3. Deny policy does not cover the hub**
 
@@ -277,17 +277,17 @@ Because the hub RG is excluded from the deny policy, model deployments there are
 | Workload | Correct resource group | Correct account | Notes |
 |---|---|---|---|
 | Standard agents (no memory tools) | `rg-foundry-spoke-alpha-{suffix}` | `aif-spoke-alpha-{suffix}` | Uses `core-alpha/gpt-4.1-mini` via APIM connection |
-| Hosted agents | `rg-foundry-spoke-alpha-{suffix}` | `aif-spoke-alpha-{suffix}` (East US 2) | Uses existing spoke account — East US 2 is supported for hosted agents |
-| Foundry IQ (KB + agentic retrieval) | `rg-foundry-multi-{suffix}` | `aif-spoke-multi-{suffix}` (existing) | Adds `iq-project` + `iq-search-{suffix}` to the shared account. No model deployments — deny policy is not violated. `iq` is a capability qualifier, not a team name. Dedicated APIM subscription (`foundry-gateway-iq`) isolates embedding batch quota from team traffic. |
-| Custom MCP server (Contoso PMO KB, Lab 08-05) | `rg-foundry-multi-{suffix}` | `aif-spoke-multi-{suffix}` (existing) | Adds `contoso-pmo-project` to the shared account. Azure Functions app deploys into `rg-foundry-contoso-pmo-mcp`. No model deployments — deny policy unaffected. `contoso-pmo` is a capability qualifier, not a team name. Dedicated APIM subscription (`foundry-gateway-contoso-pmo`) isolates quota. |
-| Agent Observability (Lab 07-05) | `rg-foundry-multi-{suffix}` | `aif-spoke-multi-{suffix}` (existing) | Adds `obs-project` + `appi-obs-{suffix}` + `log-obs-{suffix}` to the shared account. No model deployments — deny policy unaffected. `obs` is a capability qualifier, not a team name. Dedicated APIM subscription (`foundry-gateway-obs`) isolates tracing workload quota from team traffic. |
-| Memory API + `memory_search` agents | `rg-foundry-memory-{suffix}` | `aif-memory-{suffix}` (new, with local deployments) | Dedicated RG required — local model deployments needed; deny policy must not be assigned to this RG |
-| Content Understanding (Lab 10) | `rg-foundry-cu-{suffix}` | `aif-cu-{suffix}` (new, with local deployments) | Dedicated RG required — local model deployments needed for CU field extraction; deny policy must not be assigned. `cu` is a capability qualifier, not a team name. |
+| Hosted agents | `rg-foundry-spoke-alpha-{suffix}` | `aif-spoke-alpha-{suffix}` (East US 2) | Uses existing spoke account - East US 2 is supported for hosted agents |
+| Foundry IQ (KB + agentic retrieval) | `rg-foundry-multi-{suffix}` | `aif-spoke-multi-{suffix}` (existing) | Adds `iq-project` + `iq-search-{suffix}` to the shared account. No model deployments - deny policy is not violated. `iq` is a capability qualifier, not a team name. Dedicated APIM subscription (`foundry-gateway-iq`) isolates embedding batch quota from team traffic. |
+| Custom MCP server (Contoso PMO KB, Lab 08-05) | `rg-foundry-multi-{suffix}` | `aif-spoke-multi-{suffix}` (existing) | Adds `contoso-pmo-project` to the shared account. Azure Functions app deploys into `rg-foundry-contoso-pmo-mcp`. No model deployments - deny policy unaffected. `contoso-pmo` is a capability qualifier, not a team name. Dedicated APIM subscription (`foundry-gateway-contoso-pmo`) isolates quota. |
+| Agent Observability (Lab 07-05) | `rg-foundry-multi-{suffix}` | `aif-spoke-multi-{suffix}` (existing) | Adds `obs-project` + `appi-obs-{suffix}` + `log-obs-{suffix}` to the shared account. No model deployments - deny policy unaffected. `obs` is a capability qualifier, not a team name. Dedicated APIM subscription (`foundry-gateway-obs`) isolates tracing workload quota from team traffic. |
+| Memory API + `memory_search` agents | `rg-foundry-memory-{suffix}` | `aif-memory-{suffix}` (new, with local deployments) | Dedicated RG required - local model deployments needed; deny policy must not be assigned to this RG |
+| Content Understanding (Lab 10) | `rg-foundry-cu-{suffix}` | `aif-cu-{suffix}` (new, with local deployments) | Dedicated RG required - local model deployments needed for CU field extraction; deny policy must not be assigned. `cu` is a capability qualifier, not a team name. |
 | Core model deployments | `rg-foundry-core-{suffix}` | `aif-core-{suffix}` / `aif-research-{suffix}` / `aif-oss-{suffix}` | Platform team only |
 
 ---
 
-## Architecture Diagram
+## Architecture diagram
 
 ```mermaid
 %%{init: {"theme": "base", "themeVariables": {"background": "#ffffff", "fontSize": "22px"}, "flowchart": {"padding": 24, "subGraphTitleMargin": {"top": 80, "bottom": 5}, "rankSpacing": 120}}}%%
@@ -328,7 +328,7 @@ flowchart TD
         MEM_ACC --> MEM_PROJ
         MEM_ACC --> MEM_PAD
 
-        subgraph MEM_LOCAL["aif-memory — local deployments"]
+        subgraph MEM_LOCAL["aif-memory - local deployments"]
             MEM_PAD[" "]
             MEM_M1["gpt-4.1-mini<br/>(Memory API: summarisation)"]
             MEM_M2["text-embedding-3-small<br/>(Memory API: indexing)"]
@@ -341,7 +341,7 @@ flowchart TD
         CU_PROJ["cu-project<br/>Foundry Project"]
         CU_ACC --> CU_PROJ
 
-        subgraph CU_LOCAL["aif-cu — local deployments"]
+        subgraph CU_LOCAL["aif-cu - local deployments"]
             CU_PAD[" "]
             CU_M1["gpt-4.1-mini<br/>(CU: field extraction)"]
             CU_M2["text-embedding-3-large<br/>(CU: embeddings)"]
@@ -366,20 +366,20 @@ flowchart TD
             O1["Phi-4<br/>West US 3"]
         end
 
-        APIM -->|"Managed Identity — default"| HUB
-        APIM -->|"Managed Identity — /deployments/o3-deep-research/"| RES
-        APIM -->|"Managed Identity — /deployments/Phi-4/"| OSS
+        APIM -->|"Managed Identity - default"| HUB
+        APIM -->|"Managed Identity - /deployments/o3-deep-research/"| RES
+        APIM -->|"Managed Identity - /deployments/Phi-4/"| OSS
     end
 
-    ALPHA_PROJ -->|"core-alpha — ALPHA_GATEWAY_KEY"| APIM
-    BETA_PROJ  -->|"core-beta — BETA_GATEWAY_KEY"| APIM
-    DELTA_PROJ -->|"core-delta — DELTA_GATEWAY_KEY"| APIM
-    GAMMA_PROJ -->|"core-gamma — GAMMA_GATEWAY_KEY"| APIM
-    MEM_PROJ   -->|"core-alpha — ALPHA_GATEWAY_KEY"| APIM
-    IQ_PROJ    -->|"landing-zone-apim — IQ_GATEWAY_KEY"| APIM
-    CONTOSO_PMO_PROJ -->|"landing-zone-apim — CONTOSO_PMO_GATEWAY_KEY"| APIM
-    OBS_PROJ    -->|"landing-zone-apim — OBS_GATEWAY_KEY"| APIM
-    CU_PROJ     -->|"landing-zone-apim — CU_GATEWAY_KEY"| APIM
+    ALPHA_PROJ -->|"core-alpha - ALPHA_GATEWAY_KEY"| APIM
+    BETA_PROJ  -->|"core-beta - BETA_GATEWAY_KEY"| APIM
+    DELTA_PROJ -->|"core-delta - DELTA_GATEWAY_KEY"| APIM
+    GAMMA_PROJ -->|"core-gamma - GAMMA_GATEWAY_KEY"| APIM
+    MEM_PROJ   -->|"core-alpha - ALPHA_GATEWAY_KEY"| APIM
+    IQ_PROJ    -->|"landing-zone-apim - IQ_GATEWAY_KEY"| APIM
+    CONTOSO_PMO_PROJ -->|"landing-zone-apim - CONTOSO_PMO_GATEWAY_KEY"| APIM
+    OBS_PROJ    -->|"landing-zone-apim - OBS_GATEWAY_KEY"| APIM
+    CU_PROJ     -->|"landing-zone-apim - CU_GATEWAY_KEY"| APIM
 
     class APIM apim
     class ALPHA_ACC,MULTI_ACC,MEM_ACC,CU_ACC account
@@ -417,22 +417,26 @@ flowchart TD
 | Color | Component type | Description |
 |-------|---------------|-------------|
 | **Orange** | API Management (APIM) | The central gateway. Receives all model requests from team project connections and routes them to the correct Foundry account backend using managed identity authentication. A single APIM instance serves all teams and capability workloads. |
-| **Blue** | Foundry Account | The top-level Azure AI Foundry resource — the billing, governance, and quota boundary. Standalone spoke accounts (solid blue node) hold no model deployments of their own. Hub accounts that host model deployments are shown as blue-bordered containers. |
-| **Teal** | Foundry Project | The team or capability workspace inside a Foundry Account. Each project is isolated — agents, connections, and data are scoped to the project. Projects connect to the APIM gateway through a named connection registered on the project. |
-| **Purple** | Model Deployment | A model deployed on a Foundry Account. Core models (in `aif-core`, `aif-research`, `aif-oss`) are accessed via APIM — agents reference them as `{connection}/{model}`. Memory models (in `aif-memory`) are accessed directly by the Memory API internal runtime — they cannot be referenced via an APIM connection for `memory_search` agents. |
+| **Blue** | Foundry Account | The top-level Azure AI Foundry resource - the billing, governance, and quota boundary. Standalone spoke accounts (solid blue node) hold no model deployments of their own. Hub accounts that host model deployments are shown as blue-bordered containers. |
+| **Teal** | Foundry Project | The team or capability workspace inside a Foundry Account. Each project is isolated - agents, connections, and data are scoped to the project. Projects connect to the APIM gateway through a named connection registered on the project. |
+| **Purple** | Model Deployment | A model deployed on a Foundry Account. Core models (in `aif-core`, `aif-research`, `aif-oss`) are accessed via APIM - agents reference them as `{connection}/{model}`. Memory models (in `aif-memory`) are accessed directly by the Memory API internal runtime - they cannot be referenced via an APIM connection for `memory_search` agents. |
 | **Steel blue** | Azure AI Search | An Azure AI Search service hosting one or more indexes, knowledge sources, and knowledge bases. Solid arrows show MCP RemoteTool connections from Foundry projects; dashed arrows show the integrated vectorizer calling the APIM gateway for query-time embeddings. |
 
 **Resource groups and account containers:**
 
 | Colour | Resource group / container | Description |
 |--------|---------------------------|-------------|
-| Amber | `rg-foundry-spoke-alpha` | 1:1 Spoke — Team Alpha's dedicated Foundry account and project (Labs 1B / 1C / 07-03). Contains the spoke account (`aif-spoke-alpha`, East US 2). Hosted agents also run here using the existing account. Model deployments denied by policy. |
-| Green | `rg-foundry-multi` | 1:N Multi-Project — shared Foundry account with projects for Teams Beta, Delta, and Gamma (Lab 1C) plus the `iq-project` capability workload and `iq-search-{suffix}` Azure AI Search service (Lab 08), the `contoso-pmo-project` capability workload (Lab 09), and the `obs-project` capability workload with `appi-obs-{suffix}` Application Insights (Lab 07-05). Model deployments denied by policy (unaffected by the search service, Functions app, or Application Insights, which are different resource types). |
-| Rose | `rg-foundry-memory` | Memory API — dedicated Foundry account (`aif-memory`) with local model deployments for the Memory API (Lab 07-04). Intentionally excluded from the deny-model-deployments policy. |
-| Sky blue | `rg-foundry-core` | Landing Zone — shared APIM gateway and all hub Foundry accounts with model deployments (Labs 1A / 1C). Platform team owned; application teams have no write access. |
-| Light blue | `aif-core` | Primary core Foundry Account — hosts general-purpose and routing model deployments (East US 2). |
-| Light violet | `aif-research` | Research hub Foundry Account — hosts advanced reasoning model deployments (Norway East). |
-| Light fuchsia | `aif-oss` | OSS hub Foundry Account — hosts open-weights model deployments (West US 3). |
-| Light rose | `aif-memory` | Memory Foundry Account — hosts local `gpt-4.1-mini` (summarisation) and `text-embedding-3-small` (indexing) deployments consumed directly by the Memory API runtime. |
-| Amber-orange | `rg-foundry-cu` | Content Understanding — dedicated Foundry account (`aif-cu`) with local model deployments for CU field extraction (Lab 10). Intentionally excluded from the deny-model-deployments policy. |
-| Light orange | `aif-cu` | Content Understanding Foundry Account — hosts local `gpt-4.1-mini` (field extraction) and `text-embedding-3-large` (embeddings) deployments consumed by CU analyzers. |
+| Amber | `rg-foundry-spoke-alpha` | 1:1 Spoke - Team Alpha's dedicated Foundry account and project (Labs 1B / 1C / 07-03). Contains the spoke account (`aif-spoke-alpha`, East US 2). Hosted agents also run here using the existing account. Model deployments denied by policy. |
+| Green | `rg-foundry-multi` | 1:N Multi-Project - shared Foundry account with projects for Teams Beta, Delta, and Gamma (Lab 1C) plus the `iq-project` capability workload and `iq-search-{suffix}` Azure AI Search service (Lab 08), the `contoso-pmo-project` capability workload (Lab 09), and the `obs-project` capability workload with `appi-obs-{suffix}` Application Insights (Lab 07-05). Model deployments denied by policy (unaffected by the search service, Functions app, or Application Insights, which are different resource types). |
+| Rose | `rg-foundry-memory` | Memory API - dedicated Foundry account (`aif-memory`) with local model deployments for the Memory API (Lab 07-04). Intentionally excluded from the deny-model-deployments policy. |
+| Sky blue | `rg-foundry-core` | Landing Zone - shared APIM gateway and all hub Foundry accounts with model deployments (Labs 1A / 1C). Platform team owned; application teams have no write access. |
+| Light blue | `aif-core` | Primary core Foundry Account - hosts general-purpose and routing model deployments (East US 2). |
+| Light violet | `aif-research` | Research hub Foundry Account - hosts advanced reasoning model deployments (Norway East). |
+| Light fuchsia | `aif-oss` | OSS hub Foundry Account - hosts open-weights model deployments (West US 3). |
+| Light rose | `aif-memory` | Memory Foundry Account - hosts local `gpt-4.1-mini` (summarisation) and `text-embedding-3-small` (indexing) deployments consumed directly by the Memory API runtime. |
+| Amber-orange | `rg-foundry-cu` | Content Understanding - dedicated Foundry account (`aif-cu`) with local model deployments for CU field extraction (Lab 10). Intentionally excluded from the deny-model-deployments policy. |
+| Light orange | `aif-cu` | Content Understanding Foundry Account - hosts local `gpt-4.1-mini` (field extraction) and `text-embedding-3-large` (embeddings) deployments consumed by CU analyzers. |
+
+---
+
+[Next: Deploy core gateway →](05-02-deploy-foundry-core-gateway/deploy-foundry-core-gateway.ipynb)

--- a/05-foundry-project-pattern-setup/05-01-architecture.md
+++ b/05-foundry-project-pattern-setup/05-01-architecture.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-The Lab 1 series deploys a **centralised AI gateway pattern**: a single API Management instance acts as the entry point for all model traffic, routing requests to multiple regional Foundry accounts based on the model being called. Teams access this gateway through their own Foundry project workspaces, each authenticated with a dedicated APIM subscription key for independent rate limiting and usage tracking.
+This section series deploys a **centralised AI gateway pattern**: a single BYO (Bring Your Own) API Management instance acts as the entry point for all model traffic, routing requests to multiple regional Foundry accounts based on the model being called. Teams access this gateway through their own Foundry project workspaces, each authenticated with a dedicated APIM subscription key for independent rate limiting and usage tracking.
 
 Two Foundry provisioning patterns are demonstrated side-by-side:
 
-- **1:1 Spoke** (Lab 1B) - Team Alpha has its own dedicated Foundry account, giving it a hard infrastructure boundary. This suits teams with strict compliance or cost isolation requirements.
-- **1:N Multi-Project** (Lab 1C) - Teams Beta, Delta, and Gamma share a single Foundry account with project-level isolation. This is the preferred pattern for teams in the same department or cost centre.
+- **1:1 Spoke** - Team Alpha has its own dedicated Foundry account, giving it a hard infrastructure boundary. This suits teams with strict compliance or cost isolation requirements.
+- **1:N Multi-Project** - Teams Beta, Delta, and Gamma share a single Foundry account with project-level isolation. This is the preferred pattern for teams in the same department or cost centre.
 
 Neither pattern changes how teams reach the gateway or which models they can use - that is determined entirely by their project connection and APIM subscription.
 
@@ -27,7 +27,7 @@ The shared infrastructure backbone. All team projects route model requests throu
 |----------|------|--------|------------|---------|
 | `apim-foundry-{suffix}` | API Management BasicV2 | East US 2 | `GATEWAY_URL` | Central gateway - single URL for all model access |
 | `aif-core-{suffix}` | Foundry Account (AI Services) | East US 2 | `CORE_ENDPOINT` | Primary core: general purpose and routing models |
-| `project-admin-{suffix}` | Foundry Project (child of `aif-core`) | East US 2 | `ADMIN_FOUNDRY_PROJECT_ENDPOINT` | Admin project: hosts centrally-managed agents, evaluations, observability, and load-gen workloads (08-05, 08-06, 08-07, 20-*) |
+| `project-admin-{suffix}` | Foundry Project (child of `aif-core`) | East US 2 | `ADMIN_FOUNDRY_PROJECT_ENDPOINT` | Admin project: hosts centrally-managed agents, evaluations, observability, and load-gen workloads |
 | `aif-research-{suffix}` | Foundry Account (AI Services) | Norway East | - | Research hub: advanced reasoning models |
 | `aif-oss-{suffix}` | Foundry Account (AI Services) | West US 3 | - | OSS hub: open-weights models |
 | `stfoundry{suffix}` | Storage Account | East US 2 | - | Shared storage |
@@ -71,10 +71,10 @@ The shared infrastructure backbone. All team projects route model requests throu
 | `foundry-gateway-beta` | `openai` API | `BETA_GATEWAY_KEY` | Team Beta |
 | `foundry-gateway-delta` | `openai` API | `DELTA_GATEWAY_KEY` | Team Delta |
 | `foundry-gateway-gamma` | `openai` API | `GAMMA_GATEWAY_KEY` | Team Gamma |
-| `foundry-gateway-iq` | `openai` API | `IQ_GATEWAY_KEY` | Lab 10 Foundry IQ - isolated from team quotas; the embedding batch ingest for 3,000 documents generates ~6M tokens and must not compete with team traffic |
-| `foundry-gateway-contoso-pmo` | `openai` API | `CONTOSO_PMO_GATEWAY_KEY` | Lab 08-05 Contoso PMO KB - dedicated MCP server workload; avoids competing with team inference traffic |
-| `foundry-gateway-cu` | `openai` API | `CU_GATEWAY_KEY` | Lab 10 Content Understanding - dedicated CU workload quota; also gates access to the `/cu` APIM API |
-| `foundry-gateway-obs` | `openai` API | `OBS_GATEWAY_KEY` | Lab 07-05 Agent Observability - dedicated APIM subscription isolates tracing workload quota from team traffic |
+| `foundry-gateway-iq` | `openai` API | `IQ_GATEWAY_KEY` | Foundry IQ - isolated from team quotas; the embedding batch ingest for 3,000 documents generates ~6M tokens and must not compete with team traffic |
+| `foundry-gateway-contoso-pmo` | `openai` API | `CONTOSO_PMO_GATEWAY_KEY` | Contoso PMO KB - dedicated MCP server workload; avoids competing with team inference traffic |
+| `foundry-gateway-cu` | `openai` API | `CU_GATEWAY_KEY` | Content Understanding - dedicated CU workload quota; also gates access to the `/cu` APIM API |
+| `foundry-gateway-obs` | `openai` API | `OBS_GATEWAY_KEY` | Agent Observability - dedicated APIM subscription isolates tracing workload quota from team traffic |
 
 ---
 
@@ -93,24 +93,24 @@ Model access via connection: `core-alpha/gpt-4.1-mini`
 
 ---
 
-### Teams Beta, Delta, Gamma + Lab 09 Foundry IQ Multi-Agent + Lab 10 Foundry IQ + Lab 08-05 Contoso PMO KB + Lab 07-05 Observability: `rg-foundry-multi-{suffix}` (1:N pattern)
+### Teams Beta, Delta, Gamma + Foundry IQ Multi-Agent + Foundry IQ + Contoso PMO KB + Agent Observability: `rg-foundry-multi-{suffix}` (1:N pattern)
 
-Three teams share one Foundry account (`aif-spoke-multi-{suffix}`). Project-level isolation ensures each team's agents and data remain separate. Lab 09 (Foundry IQ Multi-Agent) extends this account with a `contoso-project` and a dedicated Standard SKU Azure AI Search service; Lab 10 (Foundry IQ) extends this account with a fourth project (`iq-project`) and a dedicated Azure AI Search service; Lab 08-05 (Contoso PMO KB) adds a fifth project (`contoso-pmo-project`) for the custom MCP server workload; Lab 07-05 (Agent Observability) adds a sixth project (`obs-project`) with Application Insights - all demonstrating the 1:N pattern absorbing successive capability workloads without creating new Foundry accounts.
+Three teams share one Foundry account (`aif-spoke-multi-{suffix}`). Project-level isolation ensures each team's agents and data remain separate. Foundry IQ Multi-Agent extends this account with a `contoso-project` and a dedicated Standard SKU Azure AI Search service; Foundry IQ extends this account with a fourth project (`iq-project`) and a dedicated Azure AI Search service; Contoso PMO KB adds a fifth project (`contoso-pmo-project`) for the custom MCP server workload; Agent Observability adds a sixth project (`obs-project`) with Application Insights - all demonstrating the 1:N pattern absorbing successive capability workloads without creating new Foundry accounts.
 
 | Resource | Type | `.env` keys | Added by |
 |----------|------|-------------|----------|
-| `aif-spoke-multi-{suffix}` | Foundry Account (shared) | `MULTI_ACCOUNT`, `MULTI_ACCOUNT_ENDPOINT` | Lab 1C |
-| `project-beta-{suffix}` | Foundry Project - Team Beta | `BETA_FOUNDRY_PROJECT`, `BETA_FOUNDRY_PROJECT_ENDPOINT` | Lab 1C |
-| `project-delta-{suffix}` | Foundry Project - Team Delta | `DELTA_FOUNDRY_PROJECT`, `DELTA_FOUNDRY_PROJECT_ENDPOINT` | Lab 1C |
-| `project-gamma-{suffix}` | Foundry Project - Team Gamma | `GAMMA_FOUNDRY_PROJECT`, `GAMMA_FOUNDRY_PROJECT_ENDPOINT` | Lab 1C |
-| `contoso-project` | Foundry Project - Lab 09 Foundry IQ Multi-Agent | `CONTOSO_FOUNDRY_PROJECT`, `CONTOSO_FOUNDRY_PROJECT_ENDPOINT` | Lab 09 |
-| `contoso-search-{suffix}` | Azure AI Search (Standard, SystemAssigned identity) | `CONTOSO_SEARCH_ENDPOINT`, `CONTOSO_SEARCH_NAME` | Lab 09 |
-| `iq-project` | Foundry Project - Lab 10 Foundry IQ | `IQ_FOUNDRY_PROJECT`, `IQ_FOUNDRY_PROJECT_ENDPOINT` | Lab 10 |
-| `contoso-pmo-project` | Foundry Project - Lab 08-05 Contoso PMO KB | `CONTOSO_PMO_FOUNDRY_PROJECT`, `CONTOSO_PMO_FOUNDRY_PROJECT_ENDPOINT` | Lab 08-05 |
-| `iq-search-{suffix}` | Azure AI Search (Basic, SystemAssigned identity) | `IQ_SEARCH_ENDPOINT`, `IQ_SEARCH_NAME` | Lab 10 |
-| `obs-project` | Foundry Project - Lab 07-05 Agent Observability | `OBS_FOUNDRY_PROJECT_ENDPOINT` | Lab 07-05 |
-| `log-obs-{suffix}` | Log Analytics Workspace | - | Lab 07-05 |
-| `appi-obs-{suffix}` | Application Insights | `OBS_APP_INSIGHTS_NAME`, `OBS_APP_INSIGHTS_CONN_STRING` | Lab 07-05 |
+| `aif-spoke-multi-{suffix}` | Foundry Account (shared) | `MULTI_ACCOUNT`, `MULTI_ACCOUNT_ENDPOINT` | Multi-project deployment |
+| `project-beta-{suffix}` | Foundry Project - Team Beta | `BETA_FOUNDRY_PROJECT`, `BETA_FOUNDRY_PROJECT_ENDPOINT` | Multi-project deployment |
+| `project-delta-{suffix}` | Foundry Project - Team Delta | `DELTA_FOUNDRY_PROJECT`, `DELTA_FOUNDRY_PROJECT_ENDPOINT` | Multi-project deployment |
+| `project-gamma-{suffix}` | Foundry Project - Team Gamma | `GAMMA_FOUNDRY_PROJECT`, `GAMMA_FOUNDRY_PROJECT_ENDPOINT` | Multi-project deployment |
+| `contoso-project` | Foundry Project - Foundry IQ Multi-Agent | `CONTOSO_FOUNDRY_PROJECT`, `CONTOSO_FOUNDRY_PROJECT_ENDPOINT` | Foundry IQ Multi-Agent |
+| `contoso-search-{suffix}` | Azure AI Search (Standard, SystemAssigned identity) | `CONTOSO_SEARCH_ENDPOINT`, `CONTOSO_SEARCH_NAME` | Foundry IQ Multi-Agent |
+| `iq-project` | Foundry Project - Foundry IQ | `IQ_FOUNDRY_PROJECT`, `IQ_FOUNDRY_PROJECT_ENDPOINT` | Foundry IQ |
+| `contoso-pmo-project` | Foundry Project - Contoso PMO KB | `CONTOSO_PMO_FOUNDRY_PROJECT`, `CONTOSO_PMO_FOUNDRY_PROJECT_ENDPOINT` | Contoso PMO KB |
+| `iq-search-{suffix}` | Azure AI Search (Basic, SystemAssigned identity) | `IQ_SEARCH_ENDPOINT`, `IQ_SEARCH_NAME` | Foundry IQ |
+| `obs-project` | Foundry Project - Agent Observability | `OBS_FOUNDRY_PROJECT_ENDPOINT` | Agent Observability |
+| `log-obs-{suffix}` | Log Analytics Workspace | - | Agent Observability |
+| `appi-obs-{suffix}` | Application Insights | `OBS_APP_INSIGHTS_NAME`, `OBS_APP_INSIGHTS_CONN_STRING` | Agent Observability |
 
 Each project connects to the gateway via its own named APIM connection and key:
 
@@ -126,7 +126,7 @@ Each project connects to the gateway via its own named APIM connection and key:
 
 > **Connection naming**: team core connections follow `core-{team}` (e.g. `core-beta`). The `iq-project`, `contoso-pmo-project`, and `obs-project` connections are named `landing-zone-apim` because `iq`, `contoso-pmo`, and `obs` are capability qualifiers, not team names - all three use descriptive connection names that reflect what they are connecting to.
 
-**`iq-search-{suffix}` - Azure AI Search index details (Lab 10):**
+**`iq-search-{suffix}` - Azure AI Search index details (Foundry IQ):**
 
 | Index | Dimensions | Algorithm | Semantic config | KB |
 |-------|-----------|-----------|----------------|----|
@@ -136,7 +136,7 @@ The search service's managed identity is granted **Cognitive Services User** on 
 
 ---
 
-### Lab 10 Content Understanding: `rg-foundry-cu-{suffix}`
+### Content Understanding: `rg-foundry-cu-{suffix}`
 
 Content Understanding requires a **dedicated** AI Services account with local model deployments - it cannot share `aif-spoke-multi-{suffix}`, which has the `deny-model-deployments` policy assigned. A new resource group (`rg-foundry-cu-{suffix}`) is created exclusively for this lab.
 
@@ -279,10 +279,10 @@ Because the hub RG is excluded from the deny policy, model deployments there are
 | Standard agents (no memory tools) | `rg-foundry-spoke-alpha-{suffix}` | `aif-spoke-alpha-{suffix}` | Uses `core-alpha/gpt-4.1-mini` via APIM connection |
 | Hosted agents | `rg-foundry-spoke-alpha-{suffix}` | `aif-spoke-alpha-{suffix}` (East US 2) | Uses existing spoke account - East US 2 is supported for hosted agents |
 | Foundry IQ (KB + agentic retrieval) | `rg-foundry-multi-{suffix}` | `aif-spoke-multi-{suffix}` (existing) | Adds `iq-project` + `iq-search-{suffix}` to the shared account. No model deployments - deny policy is not violated. `iq` is a capability qualifier, not a team name. Dedicated APIM subscription (`foundry-gateway-iq`) isolates embedding batch quota from team traffic. |
-| Custom MCP server (Contoso PMO KB, Lab 08-05) | `rg-foundry-multi-{suffix}` | `aif-spoke-multi-{suffix}` (existing) | Adds `contoso-pmo-project` to the shared account. Azure Functions app deploys into `rg-foundry-contoso-pmo-mcp`. No model deployments - deny policy unaffected. `contoso-pmo` is a capability qualifier, not a team name. Dedicated APIM subscription (`foundry-gateway-contoso-pmo`) isolates quota. |
-| Agent Observability (Lab 07-05) | `rg-foundry-multi-{suffix}` | `aif-spoke-multi-{suffix}` (existing) | Adds `obs-project` + `appi-obs-{suffix}` + `log-obs-{suffix}` to the shared account. No model deployments - deny policy unaffected. `obs` is a capability qualifier, not a team name. Dedicated APIM subscription (`foundry-gateway-obs`) isolates tracing workload quota from team traffic. |
+| Custom MCP server (Contoso PMO KB) | `rg-foundry-multi-{suffix}` | `aif-spoke-multi-{suffix}` (existing) | Adds `contoso-pmo-project` to the shared account. Azure Functions app deploys into `rg-foundry-contoso-pmo-mcp`. No model deployments - deny policy unaffected. `contoso-pmo` is a capability qualifier, not a team name. Dedicated APIM subscription (`foundry-gateway-contoso-pmo`) isolates quota. |
+| Agent Observability | `rg-foundry-multi-{suffix}` | `aif-spoke-multi-{suffix}` (existing) | Adds `obs-project` + `appi-obs-{suffix}` + `log-obs-{suffix}` to the shared account. No model deployments - deny policy unaffected. `obs` is a capability qualifier, not a team name. Dedicated APIM subscription (`foundry-gateway-obs`) isolates tracing workload quota from team traffic. |
 | Memory API + `memory_search` agents | `rg-foundry-memory-{suffix}` | `aif-memory-{suffix}` (new, with local deployments) | Dedicated RG required - local model deployments needed; deny policy must not be assigned to this RG |
-| Content Understanding (Lab 10) | `rg-foundry-cu-{suffix}` | `aif-cu-{suffix}` (new, with local deployments) | Dedicated RG required - local model deployments needed for CU field extraction; deny policy must not be assigned. `cu` is a capability qualifier, not a team name. |
+| Content Understanding | `rg-foundry-cu-{suffix}` | `aif-cu-{suffix}` (new, with local deployments) | Dedicated RG required - local model deployments needed for CU field extraction; deny policy must not be assigned. `cu` is a capability qualifier, not a team name. |
 | Core model deployments | `rg-foundry-core-{suffix}` | `aif-core-{suffix}` / `aif-research-{suffix}` / `aif-oss-{suffix}` | Platform team only |
 
 ---
@@ -426,15 +426,15 @@ flowchart TD
 
 | Colour | Resource group / container | Description |
 |--------|---------------------------|-------------|
-| Amber | `rg-foundry-spoke-alpha` | 1:1 Spoke - Team Alpha's dedicated Foundry account and project (Labs 1B / 1C / 07-03). Contains the spoke account (`aif-spoke-alpha`, East US 2). Hosted agents also run here using the existing account. Model deployments denied by policy. |
-| Green | `rg-foundry-multi` | 1:N Multi-Project - shared Foundry account with projects for Teams Beta, Delta, and Gamma (Lab 1C) plus the `iq-project` capability workload and `iq-search-{suffix}` Azure AI Search service (Lab 08), the `contoso-pmo-project` capability workload (Lab 09), and the `obs-project` capability workload with `appi-obs-{suffix}` Application Insights (Lab 07-05). Model deployments denied by policy (unaffected by the search service, Functions app, or Application Insights, which are different resource types). |
-| Rose | `rg-foundry-memory` | Memory API - dedicated Foundry account (`aif-memory`) with local model deployments for the Memory API (Lab 07-04). Intentionally excluded from the deny-model-deployments policy. |
-| Sky blue | `rg-foundry-core` | Landing Zone - shared APIM gateway and all hub Foundry accounts with model deployments (Labs 1A / 1C). Platform team owned; application teams have no write access. |
+| Amber | `rg-foundry-spoke-alpha` | 1:1 Spoke - Team Alpha's dedicated Foundry account and project. Contains the spoke account (`aif-spoke-alpha`, East US 2). Hosted agents also run here using the existing account. Model deployments denied by policy. |
+| Green | `rg-foundry-multi` | 1:N Multi-Project - shared Foundry account with projects for Teams Beta, Delta, and Gamma plus the `iq-project` (Foundry IQ) capability workload and `iq-search-{suffix}` Azure AI Search service, the `contoso-pmo-project` (Contoso PMO KB) capability workload, and the `obs-project` (Agent Observability) capability workload with `appi-obs-{suffix}` Application Insights. Model deployments denied by policy (unaffected by the search service, Functions app, or Application Insights, which are different resource types). |
+| Rose | `rg-foundry-memory` | Memory API - dedicated Foundry account (`aif-memory`) with local model deployments for the Memory API. Intentionally excluded from the deny-model-deployments policy. |
+| Sky blue | `rg-foundry-core` | Landing Zone - shared APIM gateway and all hub Foundry accounts with model deployments. Platform team owned; application teams have no write access. |
 | Light blue | `aif-core` | Primary core Foundry Account - hosts general-purpose and routing model deployments (East US 2). |
 | Light violet | `aif-research` | Research hub Foundry Account - hosts advanced reasoning model deployments (Norway East). |
 | Light fuchsia | `aif-oss` | OSS hub Foundry Account - hosts open-weights model deployments (West US 3). |
 | Light rose | `aif-memory` | Memory Foundry Account - hosts local `gpt-4.1-mini` (summarisation) and `text-embedding-3-small` (indexing) deployments consumed directly by the Memory API runtime. |
-| Amber-orange | `rg-foundry-cu` | Content Understanding - dedicated Foundry account (`aif-cu`) with local model deployments for CU field extraction (Lab 10). Intentionally excluded from the deny-model-deployments policy. |
+| Amber-orange | `rg-foundry-cu` | Content Understanding - dedicated Foundry account (`aif-cu`) with local model deployments for CU field extraction. Intentionally excluded from the deny-model-deployments policy. |
 | Light orange | `aif-cu` | Content Understanding Foundry Account - hosts local `gpt-4.1-mini` (field extraction) and `text-embedding-3-large` (embeddings) deployments consumed by CU analyzers. |
 
 ---

--- a/05-foundry-project-pattern-setup/05-01-architecture.md
+++ b/05-foundry-project-pattern-setup/05-01-architecture.md
@@ -384,7 +384,7 @@ flowchart TD
     class APIM apim
     class ALPHA_ACC,MULTI_ACC,MEM_ACC,CU_ACC account
     class ALPHA_PROJ,BETA_PROJ,DELTA_PROJ,GAMMA_PROJ,MEM_PROJ,IQ_PROJ,CONTOSO_PMO_PROJ,OBS_PROJ,CU_PROJ project
-    class H1,H2,H3,H4,R1,O1,MEM_M1,MEM_M2,CU_M1,CU_M2 model
+    class H1,H3,R1,O1,MEM_M1,MEM_M2,CU_M1,CU_M2 model
     class IQ_SEARCH search
     class APPI_OBS appi
 

--- a/05-foundry-project-pattern-setup/05-02-deploy-foundry-core-gateway/deploy-foundry-core-gateway.ipynb
+++ b/05-foundry-project-pattern-setup/05-02-deploy-foundry-core-gateway/deploy-foundry-core-gateway.ipynb
@@ -5,22 +5,22 @@
    "id": "5b4c9ec9",
    "metadata": {},
    "source": [
-    "Core Gateway Deployment\n",
+    "# Core gateway deployment\n",
     "\n",
     "Deploy the central **Core Gateway** that all project teams connect to.\n",
     "\n",
-    "## What Gets Deployed\n",
+    "## What gets deployed\n",
     "\n",
     "| Resource | Type | Purpose |\n",
     "|----------|------|---------|\n",
-    "| `aif-core-{suffix}` | Foundry account (eastus2) | Primary core — shared chat + embedding models for all teams |\n",
-    "| `aif-research-{suffix}` | Foundry account (norwayeast) | Research hub — reasoning/research models |\n",
-    "| `aif-oss-{suffix}` | Foundry account (westus3) | OSS hub — open source/open-weights models |\n",
+    "| `aif-core-{suffix}` | Foundry account (eastus2) | Primary core - shared chat + embedding models for all teams |\n",
+    "| `aif-research-{suffix}` | Foundry account (norwayeast) | Research hub - reasoning/research models |\n",
+    "| `aif-oss-{suffix}` | Foundry account (westus3) | OSS hub - open source/open-weights models |\n",
     "| `apim-foundry-{suffix}` | API Management (BasicV2) | Gateway with rate limiting and managed identity auth |\n",
     "| `stfoundry{suffix}` | Storage account | Shared storage |\n",
-    "| `project-admin-{suffix}` | Foundry project (child of aif-core) | Admin project — hosts centrally-managed agents, evaluations, observability, and load-gen |\n",
+    "| `project-admin-{suffix}` | Foundry project (child of aif-core) | Admin project - hosts centrally-managed agents, evaluations, observability, and load-gen |\n",
     "\n",
-    "## Model Deployments\n",
+    "## Model deployments\n",
     "\n",
     "| Model | Hub | Purpose |\n",
     "|-------|-----|---------|\n",
@@ -29,7 +29,7 @@
     "| `o3-deep-research` | aif-research | Advanced reasoning (only available in norwayeast) |\n",
     "| `Phi-4` | aif-oss | Open-weights model from Microsoft (westus3) |\n",
     "\n",
-    "## Naming Conventions\n",
+    "## Naming conventions\n",
     "\n",
     "Resources follow [Azure CAF abbreviations](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations):\n",
     "- `aif` = Foundry account (`Microsoft.CognitiveServices/accounts` kind `AIServices`)\n",
@@ -38,11 +38,11 @@
     "- `rg` = Resource group\n",
     "\n",
     "Foundry account names describe **role**, not model names or regions:\n",
-    "- `aif-core` — the default endpoint all teams use; models here are interchangeable\n",
-    "- `aif-research` — reasoning/research capability; region is an infrastructure detail\n",
-    "- `aif-oss` — open source/open-weights model tier; name stays valid if the specific model changes\n",
+    "- `aif-core` - the default endpoint all teams use; models here are interchangeable\n",
+    "- `aif-research` - reasoning/research capability; region is an infrastructure detail\n",
+    "- `aif-oss` - open source/open-weights model tier; name stays valid if the specific model changes\n",
     "\n",
-    "## Multi-Region Pattern\n",
+    "## Multi-region pattern\n",
     "\n",
     "Some models are only available in specific regions (o3-deep-research → norwayeast, Phi-4 → westus3). Rather than exposing multiple endpoints to consumers, APIM provides a **single gateway URL** and routes requests to the correct regional backend based on the deployment name in the URL path."
    ]
@@ -65,7 +65,7 @@
    "id": "7c90898d",
    "metadata": {},
    "source": [
-    "## Step 2: Set Variables"
+    "## Step 2: Set variables"
    ]
   },
   {
@@ -103,7 +103,7 @@
    "id": "58a39a5d",
    "metadata": {},
    "source": [
-    "## Step 3: Create Resource Group"
+    "## Step 3: Create resource group"
    ]
   },
   {
@@ -131,7 +131,7 @@
    "id": "f284bf4d",
    "metadata": {},
    "source": [
-    "## Step 4: Deploy Infrastructure\n",
+    "## Step 4: Deploy infrastructure\n",
     "\n",
     "⏱️ Takes ~5-10 minutes (APIM is slow)"
    ]
@@ -146,7 +146,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Principal ID: 5db0aa5d-f281-47a3-9720-04727dec61e8\n",
+      "Principal ID: 00000000-0000-0000-0000-000000000000\n",
       "Suffix:       c2676f\n",
       "\u001b[?1h\u001b=\u001b[93mA new Bicep release is available: v0.43.8. Upgrade now by running \"az bicep upgrade\".\u001b[0m\n",
       "\u001b[KName    State      Timestamp                         Mode         ResourceGroup\n",
@@ -173,7 +173,7 @@
    "id": "c4c4a631",
    "metadata": {},
    "source": [
-    "## Step 5: Get Outputs"
+    "## Step 5: Get outputs"
    ]
   },
   {
@@ -198,7 +198,7 @@
       "Admin Project:     project-admin-c2676f\n",
       "Admin Endpoint:    https://aif-core-c2676f.services.ai.azure.com/api/projects/project-admin-c2676f\n",
       "\n",
-      "✅ Outputs saved to /home/jp/development/corticalstack/foundry-nextgen/.env\n"
+      "✅ Outputs saved to <repo-root>/.env\n"
      ]
     }
    ],
@@ -275,8 +275,8 @@
    "id": "ca6196a5",
    "metadata": {},
    "source": [
-    "## Step 6: Test the Chat Model\n",
-    "Dependencies are managed via pyproject.toml — run `uv sync` in the repo root if packages are missing"
+    "## Step 6: Test the chat model\n",
+    "Dependencies are managed via pyproject.toml - run `uv sync` in the repo root if packages are missing"
    ]
   },
   {
@@ -320,7 +320,7 @@
    "id": "af301d2f",
    "metadata": {},
    "source": [
-    "## Step 7: Test the Embedding Model"
+    "## Step 7: Test the embedding model"
    ]
   },
   {
@@ -363,7 +363,7 @@
    "id": "f55ed508",
    "metadata": {},
    "source": [
-    "## Step 8: Test the Research Model via APIM\n",
+    "## Step 8: Test the research model via APIM\n",
     "\n",
     "The research model is routed through APIM to the research hub backend automatically."
    ]
@@ -422,7 +422,7 @@
    "source": [
     "---\n",
     "\n",
-    "## Troubleshooting: Soft Delete\n",
+    "## Troubleshooting: soft delete\n",
     "\n",
     "Two resource types deployed here have **soft delete** enabled by default. When you delete the resource group they are retained in a soft-deleted state and must be explicitly purged before redeploying with the same names.\n",
     "\n",
@@ -469,7 +469,7 @@
       "AIServices  norwayeast     aif-research-contoso-e84b7b\n",
       "DeletionDate                      Location        Name                 ScheduledPurgeDate                ServiceId\n",
       "--------------------------------  --------------  -------------------  --------------------------------  -------------------------------------------------------------------------------------------------------------------------------------------------------\n",
-      "2026-05-08T18:32:22.934306+00:00  Sweden Central  apim-contoso-e84b7b  2026-05-10T18:31:29.209861+00:00  /subscriptions/025aba94-0c4a-443d-8826-466477e2850f/resourceGroups/rg-contoso-core-e84b7b/providers/Microsoft.ApiManagement/service/apim-contoso-e84b7b\n"
+      "2026-05-08T18:32:22.934306+00:00  Sweden Central  apim-contoso-e84b7b  2026-05-10T18:31:29.209861+00:00  /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-contoso-core-e84b7b/providers/Microsoft.ApiManagement/service/apim-contoso-e84b7b\n"
      ]
     }
    ],
@@ -486,7 +486,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Purge soft-deleted resources — uncomment and run as needed\n",
+    "# Purge soft-deleted resources - uncomment and run as needed\n",
     "\n",
     "# Cognitive Services (Foundry accounts)\n",
     "#!az cognitiveservices account purge -l eastus2    -g \"{RG}\" -n \"aif-core-{SUFFIX}\"\n",

--- a/05-foundry-project-pattern-setup/05-02-deploy-foundry-core-gateway/main.bicep
+++ b/05-foundry-project-pattern-setup/05-02-deploy-foundry-core-gateway/main.bicep
@@ -2,7 +2,7 @@ targetScope = 'resourceGroup'
 
 param location string = resourceGroup().location
 param deployerPrincipalId string
-@description('Short unique suffix for resource names — computed from subscription ID in the notebook.')
+@description('Short unique suffix for resource names - computed from subscription ID in the notebook.')
 param suffix string
 
 @description('Location for OSS hub deployment.')
@@ -54,7 +54,7 @@ resource embeddingModel 'Microsoft.CognitiveServices/accounts/deployments@2025-0
   dependsOn: [model]
 }
 
-// Admin project — hosts centrally-managed agents, evaluations, observability and load-gen
+// Admin project - hosts centrally-managed agents, evaluations, observability and load-gen
 // workloads (08-05 MCP, 08-06 offline eval, 08-07 live obs, 20-* load gen, 04-09 cheat sheet).
 // Lives natively on the core hub so it can use the gpt-4.1-mini and embedding deployments
 // directly without going through APIM (keyless, RBAC-only).
@@ -70,7 +70,7 @@ resource adminProject 'Microsoft.CognitiveServices/accounts/projects@2025-04-01-
 }
 
 // =============================================================================
-// OSS HUB — open source/community models (westus3/australiaeast/swedencentral)
+// OSS HUB - open source/community models (westus3/australiaeast/swedencentral)
 // =============================================================================
 
 resource ossHub 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
@@ -101,7 +101,7 @@ resource ossHub 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
 }
 
 // =============================================================================
-// RESEARCH HUB — reasoning/research models (norwayeast)
+// RESEARCH HUB - reasoning/research models (norwayeast)
 // =============================================================================
 
 resource researchHub 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' = {
@@ -134,7 +134,7 @@ resource researchModel 'Microsoft.CognitiveServices/accounts/deployments@2025-04
 
 // v2 tier (BasicV2/StandardV2/PremiumV2) required for BYO AI Gateway feature with Foundry Agents.
 // BasicV2 is sufficient for public Foundry resources. If the Foundry resource has public network
-// access disabled, switch to StandardV2 or PremiumV2 — only those support the private endpoint
+// access disabled, switch to StandardV2 or PremiumV2 - only those support the private endpoint
 // (or VNet injection on PremiumV2) needed to reach a private Foundry resource.
 // See: https://learn.microsoft.com/en-us/azure/foundry/configuration/enable-ai-api-management-gateway-portal
 resource apim 'Microsoft.ApiManagement/service@2024-06-01-preview' = {
@@ -230,7 +230,7 @@ resource researchBackend 'Microsoft.ApiManagement/service/backends@2024-06-01-pr
   properties: {
     url: '${researchHub.properties.endpoint}openai'
     protocol: 'http'
-    description: 'Research hub — reasoning and research models'
+    description: 'Research hub - reasoning and research models'
   }
 }
 
@@ -241,7 +241,7 @@ resource ossBackend 'Microsoft.ApiManagement/service/backends@2024-06-01-preview
   properties: {
     url: '${ossHub.properties.endpoint}openai'
     protocol: 'http'
-    description: 'OSS hub — open source and community models'
+    description: 'OSS hub - open source and community models'
   }
 }
 
@@ -274,7 +274,7 @@ resource chatOp 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-prev
   }
 }
 
-// Chat Completions — research hub (URL match on o3-deep-research routes here)
+// Chat Completions - research hub (URL match on o3-deep-research routes here)
 resource chatResearchOp 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
   parent: api
   name: 'chat-research'
@@ -295,7 +295,7 @@ resource chatResearchPolicy 'Microsoft.ApiManagement/service/apis/operations/pol
   }
 }
 
-// Chat Completions — OSS hub (URL match on Phi-4 routes here)
+// Chat Completions - OSS hub (URL match on Phi-4 routes here)
 resource chatOssOp 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
   parent: api
   name: 'chat-oss'

--- a/05-foundry-project-pattern-setup/05-03-deploy-foundry-project-spoke/deploy-foundry-project-spoke.ipynb
+++ b/05-foundry-project-pattern-setup/05-03-deploy-foundry-project-spoke/deploy-foundry-project-spoke.ipynb
@@ -5,11 +5,11 @@
    "id": "a3052fb8",
    "metadata": {},
    "source": [
-    "Project Spoke Deployment\n",
+    "# Project spoke deployment\n",
     "\n",
     "Deploy a **Project Team (Spoke)** that connects to the Core Gateway.\n",
     "\n",
-    "## What Gets Deployed\n",
+    "## What gets deployed\n",
     "\n",
     "| Resource | Purpose |\n",
     "|----------|--------|\n",
@@ -17,7 +17,7 @@
     "| Foundry Project | Workspace for the team |\n",
     "| Core Gateway Connection | Gateway connection to core models (API Key auth) |\n",
     "\n",
-    "## Key Requirements\n",
+    "## Key requirements\n",
     "\n",
     "- **Connection Auth**: Uses API Key authentication (AAD not yet supported for APIM connections)\n",
     "- **Connection Target**: Must include the API path (e.g., `https://apim.azure-api.net/openai`)\n",
@@ -31,7 +31,7 @@
    "id": "7921907e",
    "metadata": {},
    "source": [
-    "## Step 1: Load Core Configuration"
+    "## Step 1: Load core configuration"
    ]
   },
   {
@@ -81,7 +81,7 @@
    "id": "f356d001",
    "metadata": {},
    "source": [
-    "## Step 2: Set Spoke Variables"
+    "## Step 2: Set spoke variables"
    ]
   },
   {
@@ -105,11 +105,11 @@
     "import hashlib, subprocess\n",
     "\n",
     "# Set the team name for this spoke deployment\n",
-    "# Used to namespace resources and .env keys — allows multiple spokes in the same subscription\n",
+    "# Used to namespace resources and .env keys - allows multiple spokes in the same subscription\n",
     "TEAM_NAME = \"alpha\"\n",
     "TEAM_PREFIX = TEAM_NAME.upper().replace('-', '_')  # e.g. \"alpha\" -> \"ALPHA\"\n",
     "\n",
-    "# Same suffix as Lab 1A — derived from subscription ID\n",
+    "# Same suffix as Lab 1A - derived from subscription ID\n",
     "SUB_ID = subprocess.run('az account show --query id -o tsv', shell=True, capture_output=True, text=True).stdout.strip()\n",
     "SUFFIX = hashlib.sha256((SUB_ID + 'v2').encode()).hexdigest()[:6]\n",
     "\n",
@@ -128,7 +128,7 @@
    "id": "27c32890",
    "metadata": {},
    "source": [
-    "## Step 3: Create Resource Group"
+    "## Step 3: Create resource group"
    ]
   },
   {
@@ -156,7 +156,7 @@
    "id": "e3d3d2cf",
    "metadata": {},
    "source": [
-    "## Step 4: Deploy Spoke Infrastructure\n",
+    "## Step 4: Deploy spoke infrastructure\n",
     "\n",
     "⏱️ Takes ~2-3 minutes"
    ]
@@ -171,7 +171,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Principal ID: 5db0aa5d-f281-47a3-9720-04727dec61e8\n",
+      "Principal ID: 00000000-0000-0000-0000-000000000000\n",
       "Team:         alpha\n",
       "Suffix:       c2676f\n",
       "\u001b[?1h\u001b=\u001b[93mA new Bicep release is available: v0.43.8. Upgrade now by running \"az bicep upgrade\".\u001b[0m\n",
@@ -207,7 +207,7 @@
    "id": "7a6a5e5f",
    "metadata": {},
    "source": [
-    "## Step 5: Get Spoke Outputs"
+    "## Step 5: Get spoke outputs"
    ]
   },
   {
@@ -226,7 +226,7 @@
       "Project Endpoint: https://aif-spoke-alpha-c2676f.services.ai.azure.com/api/projects/project-alpha-c2676f\n",
       "Core Connection:   core-alpha\n",
       "\n",
-      "✅ Outputs saved to /home/jp/development/corticalstack/foundry-nextgen/.env under ALPHA_FOUNDRY_* keys\n"
+      "✅ Outputs saved to <repo-root>/.env under ALPHA_FOUNDRY_* keys\n"
      ]
     }
    ],
@@ -287,7 +287,7 @@
    "id": "5aac7803",
    "metadata": {},
    "source": [
-    "## Step 6: Connect to Project and Test Agent\n",
+    "## Step 6: Connect to project and test agent\n",
     "\n",
     "Now test the spoke by creating an agent that uses the APIM gateway connection."
    ]
@@ -331,7 +331,7 @@
    "id": "6d5f3865",
    "metadata": {},
    "source": [
-    "## Step 7: Create and Test Hello World Agent\n",
+    "## Step 7: Create and test Hello World agent\n",
     "\n",
     "Create a simple agent that uses the core gateway connection."
    ]
@@ -427,7 +427,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'name': 'core-alpha', 'id': '/subscriptions/025aba94-0c4a-443d-8826-466477e2850f/resourceGroups/rg-foundry-spoke-alpha-c2676f/providers/Microsoft.CognitiveServices/accounts/aif-spoke-alpha-c2676f/projects/project-alpha-c2676f/connections/core-alpha', 'type': 'ApiManagement', 'target': 'https://apim-foundry-c2676f.azure-api.net/openai', 'isDefault': True, 'credentials': {'type': 'ApiKey'}, 'metadata': {'deploymentInPath': 'true', 'inferenceAPIVersion': '2024-10-21', 'models': '[{\"name\":\"gpt-4.1-mini\",\"properties\":{\"model\":{\"name\":\"gpt-4.1-mini\",\"version\":\"\",\"format\":\"OpenAI\"}}}]'}}\n"
+      "{'name': 'core-alpha', 'id': '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-foundry-spoke-alpha-c2676f/providers/Microsoft.CognitiveServices/accounts/aif-spoke-alpha-c2676f/projects/project-alpha-c2676f/connections/core-alpha', 'type': 'ApiManagement', 'target': 'https://apim-foundry-c2676f.azure-api.net/openai', 'isDefault': True, 'credentials': {'type': 'ApiKey'}, 'metadata': {'deploymentInPath': 'true', 'inferenceAPIVersion': '2024-10-21', 'models': '[{\"name\":\"gpt-4.1-mini\",\"properties\":{\"model\":{\"name\":\"gpt-4.1-mini\",\"version\":\"\",\"format\":\"OpenAI\"}}}]'}}\n"
      ]
     }
    ],
@@ -511,7 +511,7 @@
     "- Benefit from centralized rate limiting and policies\n",
     "- Have their usage tracked for cost allocation\n",
     "\n",
-    "### Key Concepts\n",
+    "### Key concepts\n",
     "\n",
     "| Concept | Description |\n",
     "|---------|-------------|\n",
@@ -521,7 +521,7 @@
     "| PromptAgentDefinition | Defines agent with model, instructions, and tools |\n",
     "| Responses API | Invoke agents via `openai_client.responses.create()` with `agent_reference` |\n",
     "\n",
-    "## Cleanup (Optional)"
+    "## Cleanup (optional)"
    ]
   },
   {

--- a/05-foundry-project-pattern-setup/05-03-deploy-foundry-project-spoke/deploy-foundry-project-spoke.ipynb
+++ b/05-foundry-project-pattern-setup/05-03-deploy-foundry-project-spoke/deploy-foundry-project-spoke.ipynb
@@ -109,7 +109,7 @@
     "TEAM_NAME = \"alpha\"\n",
     "TEAM_PREFIX = TEAM_NAME.upper().replace('-', '_')  # e.g. \"alpha\" -> \"ALPHA\"\n",
     "\n",
-    "# Same suffix as Lab 1A - derived from subscription ID\n",
+    "# Same suffix as the core gateway deployment - derived from subscription ID\n",
     "SUB_ID = subprocess.run('az account show --query id -o tsv', shell=True, capture_output=True, text=True).stdout.strip()\n",
     "SUFFIX = hashlib.sha256((SUB_ID + 'v2').encode()).hexdigest()[:6]\n",
     "\n",

--- a/05-foundry-project-pattern-setup/05-03-deploy-foundry-project-spoke/main.bicep
+++ b/05-foundry-project-pattern-setup/05-03-deploy-foundry-project-spoke/main.bicep
@@ -6,16 +6,16 @@ param apimUrl string
 param chatModelName string = 'gpt-4.1-mini'
 @secure()
 param apimSubscriptionKey string
-@description('Short unique suffix for resource names — computed from subscription ID in the notebook.')
+@description('Short unique suffix for resource names - computed from subscription ID in the notebook.')
 param suffix string
-@description('Team identifier — used to namespace resources and env vars for multi-spoke deployments.')
+@description('Team identifier - used to namespace resources and env vars for multi-spoke deployments.')
 param teamName string
 
 // aif = Foundry account, proj = Foundry account project (CAF abbreviations)
 var spokeAccountName = 'aif-spoke-${teamName}-${suffix}'
 var projectName = 'project-${teamName}-${suffix}'
 
-// Spoke Foundry account — no model deployments, uses APIM gateway for all inference
+// Spoke Foundry account - no model deployments, uses APIM gateway for all inference
 resource spokeAccount 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' = {
   name: spokeAccountName
   location: location

--- a/05-foundry-project-pattern-setup/05-04-deploy-foundry-multi-project/deploy-foundry-multi-project.ipynb
+++ b/05-foundry-project-pattern-setup/05-04-deploy-foundry-multi-project/deploy-foundry-multi-project.ipynb
@@ -5,11 +5,11 @@
    "id": "07b40d59",
    "metadata": {},
    "source": [
-    "# 1:N Multi-Project Deployment\n",
+    "# 1:N multi-project deployment\n",
     "\n",
     "Deploy **multiple team projects** under a **single shared AI Foundry Account** -- the 1:N pattern.\n",
     "\n",
-    "## What Gets Deployed\n",
+    "## What gets deployed\n",
     "\n",
     "| Resource | Purpose |\n",
     "|----------|--------|\n",
@@ -34,7 +34,7 @@
    "id": "5100030e",
    "metadata": {},
    "source": [
-    "## Step 1: Load Core Configuration"
+    "## Step 1: Load core configuration"
    ]
   },
   {
@@ -84,7 +84,7 @@
    "id": "2923e6e6",
    "metadata": {},
    "source": [
-    "## Step 2: Set Variables"
+    "## Step 2: Set variables"
    ]
   },
   {
@@ -107,7 +107,7 @@
    "source": [
     "import hashlib, subprocess\n",
     "\n",
-    "# Derive a stable 6-char suffix from the subscription ID — same as Lab 1A\n",
+    "# Derive a stable 6-char suffix from the subscription ID - same as Lab 1A\n",
     "SUB_ID = subprocess.run('az account show --query id -o tsv', shell=True, capture_output=True, text=True).stdout.strip()\n",
     "SUFFIX = hashlib.sha256((SUB_ID + 'v2').encode()).hexdigest()[:6]\n",
     "\n",
@@ -127,7 +127,7 @@
    "id": "6129685c",
    "metadata": {},
    "source": [
-    "## Step 3: Create Resource Group"
+    "## Step 3: Create resource group"
    ]
   },
   {
@@ -155,7 +155,7 @@
    "id": "64e787ad",
    "metadata": {},
    "source": [
-    "## Step 4: Deploy 1:N Infrastructure\n",
+    "## Step 4: Deploy 1:N infrastructure\n",
     "\n",
     "Deploys one AI Foundry Account with N projects and their APIM connections.\n",
     "\n",
@@ -172,7 +172,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Principal ID: 5db0aa5d-f281-47a3-9720-04727dec61e8\n",
+      "Principal ID: 00000000-0000-0000-0000-000000000000\n",
       "Name    State      Timestamp                         Mode         ResourceGroup\n",
       "------  ---------  --------------------------------  -----------  -----------------------\n",
       "main    Succeeded  2026-05-10T11:55:37.465024+00:00  Incremental  rg-foundry-multi-c2676f\n",
@@ -218,7 +218,7 @@
    "id": "7c1de0fd",
    "metadata": {},
    "source": [
-    "## Step 5: Get Outputs"
+    "## Step 5: Get outputs"
    ]
   },
   {
@@ -244,7 +244,7 @@
       "    Endpoint:   https://aif-spoke-multi-c2676f.services.ai.azure.com/api/projects/project-gamma-c2676f\n",
       "    Connection: core-gamma\n",
       "\n",
-      "✅ Outputs saved to /home/jp/development/corticalstack/foundry-nextgen/.env\n"
+      "✅ Outputs saved to <repo-root>/.env\n"
      ]
     }
    ],
@@ -315,9 +315,9 @@
    "id": "8od16009m5a",
    "metadata": {},
    "source": [
-    "## Step 5b: Inspect Project Connections\n",
+    "## Step 5b: Inspect project connections\n",
     "\n",
-    "List the APIM connection registered on each project. Note that `credentials` only shows the auth type — the actual API key is stored securely by Foundry and never returned."
+    "List the APIM connection registered on each project. Note that `credentials` only shows the auth type - the actual API key is stored securely by Foundry and never returned."
    ]
   },
   {
@@ -390,7 +390,7 @@
    "id": "a1b2c3d4e5f6",
    "metadata": {},
    "source": [
-    "## Step 6: Create Per-Team APIM Hub Subscriptions\n",
+    "## Step 6: Create per-team APIM hub subscriptions\n",
     "\n",
     "Each team gets its own APIM hub subscription so rate limiting and usage tracking are scoped per team.\n",
     "The per-team key is then patched into that team's Foundry project connection."
@@ -451,7 +451,7 @@
     "        capture_output=True, text=True\n",
     "    )\n",
     "    if create_result.returncode != 0:\n",
-    "        print(f\"❌ {team}: subscription create failed — {create_result.stderr.strip()}\")\n",
+    "        print(f\"❌ {team}: subscription create failed - {create_result.stderr.strip()}\")\n",
     "        continue\n",
     "\n",
     "    # Retrieve the primary key for this team\n",
@@ -516,7 +516,7 @@
    "id": "f50b319b",
    "metadata": {},
    "source": [
-    "## Step 7: Test Each Project\n",
+    "## Step 7: Test each project\n",
     "\n",
     "Connect to every project independently and verify each can reach the landing zone models through its own APIM connection.\n",
     "\n",
@@ -528,7 +528,7 @@
    "id": "db3f9a71",
    "metadata": {},
    "source": [
-    "Dependencies are managed via pyproject.toml — run `uv sync` in the repo root if packages are missing."
+    "Dependencies are managed via pyproject.toml - run `uv sync` in the repo root if packages are missing."
    ]
   },
   {
@@ -616,7 +616,7 @@
    "id": "348ee0d3",
    "metadata": {},
    "source": [
-    "## Step 8: Create Per-Team Agents\n",
+    "## Step 8: Create per-team agents\n",
     "\n",
     "Each project gets its own agent -- demonstrating that agents are scoped to projects, not accounts."
    ]
@@ -713,7 +713,7 @@
     "\n",
     "You deployed the **1:N pattern**: one AI Foundry Account hosting multiple team projects.\n",
     "\n",
-    "### Key Concepts\n",
+    "### Key concepts\n",
     "\n",
     "| Concept | Description |\n",
     "|---------|-------------|\n",
@@ -722,7 +722,7 @@
     "| Agent scoping | Agents live inside a project; Team Beta cannot see Team Delta's agents |\n",
     "| Shared RBAC | Account-level `Cognitive Services User` role applies to all projects |\n",
     "| Per-project connections | Each project has its own uniquely-named APIM connection (e.g., `core-beta`) |\n",
-    "| Per-team APIM keys | Each team has its own APIM subscription — independent rate limiting and usage tracking (`BETA_GATEWAY_KEY`, `DELTA_GATEWAY_KEY`, etc.) |\n",
+    "| Per-team APIM keys | Each team has its own APIM subscription - independent rate limiting and usage tracking (`BETA_GATEWAY_KEY`, `DELTA_GATEWAY_KEY`, etc.) |\n",
     "\n",
     "### When to use 1:N vs. separate accounts\n",
     "\n",
@@ -733,7 +733,7 @@
     "| Dev / staging / prod environments | Separate accounts per environment |\n",
     "| Rapid prototyping with many small teams | 1:N to avoid account sprawl |\n",
     "\n",
-    "## Cleanup (Optional)"
+    "## Cleanup (optional)"
    ]
   },
   {
@@ -756,7 +756,7 @@
    "source": [
     "---\n",
     "\n",
-    "## Troubleshooting: IfMatchPreconditionFailed on Redeploy\n",
+    "## Troubleshooting: IfMatchPreconditionFailed on redeploy\n",
     "\n",
     "When redeploying after a prior successful run, ARM's incremental mode does a conditional PUT on existing connections using their stored ETag. If any connection was modified since the last deployment (e.g. an agent interacted with it), the ETag will no longer match and the deployment fails:\n",
     "\n",
@@ -781,7 +781,7 @@
       "✅ Deleted connection: core-delta (project: project-delta-c2676f)\n",
       "✅ Deleted connection: core-gamma (project: project-gamma-c2676f)\n",
       "\n",
-      "Connections purged — re-run Step 4 to redeploy.\n"
+      "Connections purged - re-run Step 4 to redeploy.\n"
      ]
     }
    ],
@@ -796,7 +796,7 @@
     ")\n",
     "\n",
     "if r.returncode != 0 or not r.stdout.strip():\n",
-    "    print(\"No previous deployment found — nothing to clean up\")\n",
+    "    print(\"No previous deployment found - nothing to clean up\")\n",
     "else:\n",
     "    out = json.loads(r.stdout)\n",
     "    account = out['accountName']['value']\n",
@@ -818,7 +818,7 @@
     "        else:\n",
     "            print(f\"⚠️  {conn}: {result.stderr.strip()}\")\n",
     "\n",
-    "    print(\"\\nConnections purged — re-run Step 4 to redeploy.\")"
+    "    print(\"\\nConnections purged - re-run Step 4 to redeploy.\")"
    ]
   },
   {
@@ -826,7 +826,7 @@
    "id": "cvcag8py9zf",
    "metadata": {},
    "source": [
-    "### Troubleshooting: Soft-Deleted Foundry Account\n",
+    "### Troubleshooting: soft-deleted Foundry account\n",
     "\n",
     "If you delete the resource group and try to redeploy with the same subscription, the Foundry account is soft-deleted and ARM will refuse to recreate it:\n",
     "\n",

--- a/05-foundry-project-pattern-setup/05-04-deploy-foundry-multi-project/deploy-foundry-multi-project.ipynb
+++ b/05-foundry-project-pattern-setup/05-04-deploy-foundry-multi-project/deploy-foundry-multi-project.ipynb
@@ -107,7 +107,7 @@
    "source": [
     "import hashlib, subprocess\n",
     "\n",
-    "# Derive a stable 6-char suffix from the subscription ID - same as Lab 1A\n",
+    "# Derive a stable 6-char suffix from the subscription ID - same as the core gateway deployment\n",
     "SUB_ID = subprocess.run('az account show --query id -o tsv', shell=True, capture_output=True, text=True).stdout.strip()\n",
     "SUFFIX = hashlib.sha256((SUB_ID + 'v2').encode()).hexdigest()[:6]\n",
     "\n",
@@ -729,7 +729,7 @@
     "| Scenario | Recommendation |\n",
     "|----------|----------------|\n",
     "| Teams in the same department / cost center | 1:N (this lab) |\n",
-    "| Teams with different compliance boundaries | Separate accounts (Lab 1B) |\n",
+    "| Teams with different compliance boundaries | Separate accounts (project spoke deployment) |\n",
     "| Dev / staging / prod environments | Separate accounts per environment |\n",
     "| Rapid prototyping with many small teams | 1:N to avoid account sprawl |\n",
     "\n",

--- a/05-foundry-project-pattern-setup/05-04-deploy-foundry-multi-project/main.bicep
+++ b/05-foundry-project-pattern-setup/05-04-deploy-foundry-multi-project/main.bicep
@@ -15,7 +15,7 @@ param projectCount int = 3
 @description('Team names for each project. Must have exactly projectCount entries.')
 param teamNames array = ['alpha', 'beta', 'gamma']
 
-@description('Suffix for resource names — passed from notebook to keep naming consistent across labs.')
+@description('Suffix for resource names - passed from notebook to keep naming consistent across labs.')
 param suffix string
 
 var aiAccountName = 'aif-spoke-multi-${suffix}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-22
+
+Section 05 (project pattern setup) cleanup, plus repo-wide secret-scanning tooling.
+
+### Added
+
+- gitleaks pre-commit hook (`.pre-commit-config.yaml` + `.gitleaks.toml`) with a custom, context-scoped Azure subscription-ID rule on top of the default secret rules. Runs via Docker on staged changes only.
+- Notebook output hygiene policy in `CONTRIBUTING.md`: keep outputs but scrub environment identifiers, plus local-setup steps and PR-checklist items.
+- Next-page navigation links through section 05 (05-00 to 05-01 to 05-02).
+
+### Changed
+
+- Cleaned up section 05 across all files (05-00 through 05-04, both notebooks and Bicep): sentence-case headings aligned with filenames, with vestigial section numbering removed.
+- Updated Foundry RBAC role names to the current naming (Foundry User / Project Manager / Account Owner / Owner) with a rename note and cross-reference to 04-01.
+- Replaced brittle `Lab N` cross-references with stable capability names (Foundry IQ, Foundry IQ Multi-Agent, Contoso PMO KB, Agent Observability, Content Understanding, Memory API). This also corrected several that pointed at the wrong section (for example "Lab 09 Foundry IQ Multi-Agent" is actually section 11; "Lab 07-05 Agent Observability" is 08-07).
+- Scrubbed environment identifiers from committed notebook outputs (subscription IDs, Entra principal/object IDs, local home paths) to placeholders, while keeping the demonstration outputs and the deterministic resource-name suffix.
+
+### Fixed
+
+- Architecture diagram (05-01): removed dead `H2`/`H4` node references from the mermaid `class` statement that broke stricter renderers.
+- Corrected a wrong governance-policy notebook path in 05-01 (`06-01-deploy-governance-policy.ipynb`).
+
 ## [0.2.0] - 2026-05-20
 
 Documentation pass over chapters 00-04 to improve consistency, navigability, and accuracy.
@@ -73,5 +95,6 @@ Initial public release of the **Awesome Foundry Nextgen** lab series.
 - Contributor docs: [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md),
   [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), [SECURITY.md](SECURITY.md).
 
+[0.3.0]: https://github.com/corticalstack/awesome-foundry-nextgen/releases/tag/v0.3.0
 [0.2.0]: https://github.com/corticalstack/awesome-foundry-nextgen/releases/tag/v0.2.0
 [0.1.0]: https://github.com/corticalstack/awesome-foundry-nextgen/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,42 @@ Microsoft Foundry labs — every fix, clarification, and new scenario helps.
 - **Notebooks must run top-to-bottom** against the standard `.env` after the
   prerequisite labs have run.
 
+## Local setup
+
+This repo uses [pre-commit](https://pre-commit.com) to run a [gitleaks](https://github.com/gitleaks/gitleaks)
+secret scan on every commit. Set it up once per clone:
+
+```bash
+pip install pre-commit   # or: uv tool install pre-commit
+pre-commit install
+```
+
+The hook scans only your staged changes, so it blocks new secrets or environment
+identifiers without re-flagging older content. It runs gitleaks via Docker, so
+Docker must be available locally. Rules live in [`.gitleaks.toml`](.gitleaks.toml):
+the default gitleaks rule set (API keys, tokens, connection strings) plus a
+repo-specific rule that catches Azure subscription IDs in URLs and resource paths.
+
+To scan the whole working tree manually:
+
+```bash
+docker run --rm -v "$PWD:/repo" zricethezav/gitleaks:v8.30.1 dir /repo
+```
+
+## Notebook output hygiene
+
+Committed notebooks **keep their cell outputs** - they double as a "here is what
+success looks like" reference. Because outputs are committed, treat them as content:
+
+- **Restart and Run All** before committing so outputs are coherent and in order.
+- **Scrub environment identifiers** from outputs before committing. Replace real
+  Azure subscription IDs, resource/account/function-app names, internal hostnames,
+  and any keys or tokens with placeholders (`{subscription-id}`, `{resource}`,
+  `{project}`, and so on). The pre-commit hook catches subscription IDs and common
+  secret shapes, but resource names and hostnames still need a manual pass.
+- Use the canonical all-zeros subscription ID (`00000000-0000-0000-0000-000000000000`)
+  for documented examples; it is allowlisted.
+
 ## Branching
 
 ```
@@ -44,6 +80,8 @@ Before requesting review:
 - [ ] New env vars added to [`.env.example`](.env.example)
 - [ ] Lab added (or updated) in the index table of [`README.md`](README.md)
 - [ ] No secrets in committed files (`.env`, keys, connection strings)
+- [ ] `pre-commit` hook passes (gitleaks secret scan)
+- [ ] Notebook outputs scrubbed of subscription IDs, resource names, and hostnames
 - [ ] Screenshots placed under [`docs/screenshots/`](docs/screenshots/)
 
 ## Reporting issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awesome-foundry-nextgen"
-version = "0.2.0"
+version = "0.3.0"
 description = "Hands-on labs for Microsoft Foundry — Azure's unified PaaS for enterprise AI"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Cleans up section 05 (project pattern setup) end-to-end and adds repo-wide secret-scanning tooling. Version bumped to **v0.3.0**.

**Tooling (new)**
- **gitleaks pre-commit hook** (`.pre-commit-config.yaml` + `.gitleaks.toml`): default secret rules plus a custom, context-scoped Azure subscription-ID rule (matches `subscriptions/<uuid>` paths but deliberately ignores the public role-definition GUIDs and the all-zeros placeholder). Runs via Docker on staged changes only, so it gates new leaks without re-flagging un-scrubbed older sections.
- **Notebook output hygiene policy** in `CONTRIBUTING.md`: keep outputs as expected-result references, but scrub environment identifiers. Includes local-setup steps and two new PR-checklist items.

**Section 05 content**
- Sentence-case headings aligned with filenames across all files (05-00 through 05-04, both notebooks and Bicep); vestigial section numbering removed.
- Foundry RBAC role names updated to current naming (Foundry User / Project Manager / Account Owner / Owner), with a rename note and cross-reference to 04-01.
- Replaced brittle `Lab N` cross-references with stable capability names. This also corrected several that pointed at the wrong section (e.g. "Lab 09 Foundry IQ Multi-Agent" is actually section 11; "Lab 07-05 Agent Observability" is 08-07; "Lab 10 Content Understanding" is 09, which also contradicted "Lab 10 Foundry IQ" on the same page).
- Scrubbed environment identifiers from committed notebook outputs (subscription IDs, Entra principal/object IDs, local home paths) to placeholders, keeping the demonstration outputs and the deterministic resource-name suffix. Two of the subscription IDs were in `subscriptions/<uuid>` form and were actively caught by the new gitleaks hook.
- Next-page navigation links through 05-00 -> 05-01 -> 05-02.

**Fixes**
- Architecture diagram (05-01): removed dead `H2`/`H4` node references from the mermaid `class` statement that broke stricter renderers (verified by re-rendering).
- Corrected a wrong governance-policy notebook path in 05-01.

Section 04 was scanned for `Lab N` references and is already clean (the only "Labs" is the company name "Grafana Labs"), so no 04 changes are needed here.

Full notes in `CHANGELOG.md`.

## Test plan

- [x] gitleaks pre-commit hook installs (`pre-commit install`) and blocks a staged subscription-ID leak; passes clean commits
- [x] Click the Next-page chain 05-00 -> 05-01 -> 05-02 and the cross-reference from 05-00 to 04-01's `#built-in-foundry-roles`
- [x] Architecture diagram in 05-01 renders on GitHub
- [x] Spot-check notebook outputs contain no subscription IDs, principal IDs, or local home paths
- [x] `grep -rnE 'Labs? [0-9]' 05-foundry-project-pattern-setup` returns nothing