### PR TITLE
docs: fix cross-section reference in 07-01 (v0.5.1)

### DIFF
--- a/07-model-inference/07-01-models-inference-examples.ipynb
+++ b/07-model-inference/07-01-models-inference-examples.ipynb
@@ -32,7 +32,7 @@
     "\n",
     "1. **Python environment**: Run `uv sync` from the repository root, then select the `.venv`\n",
     "   kernel in VS Code.\n",
-    "2. **`.env` file**: Must be populated by the `04-foundry-project-pattern-setup` labs:\n",
+    "2. **`.env` file**: Must be populated by the `05-foundry-project-pattern-setup` labs:\n",
     "   - `GATEWAY_URL` - APIM gateway URL (set by the core gateway deployment)\n",
     "   - `ALPHA_GATEWAY_KEY` - Team Alpha APIM subscription key (set by the core gateway deployment)\n",
     "   - `CHAT_MODEL`, `EMBEDDING_MODEL`, `RESEARCH_MODEL` - model deployment names (set by the core gateway deployment)\n",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-05-22
+
+### Fixed
+
+- Corrected a wrong-number cross-section reference in 07-01: the `.env` prerequisite pointed at `04-foundry-project-pattern-setup`, but the project pattern setup is section 05 (section 04 is the control plane). A word-boundary-guarded repo-wide audit confirmed this was the only genuine instance; other apparent matches were substrings of valid `NN-MM-slug` filenames.
+
 ## [0.5.0] - 2026-05-22
 
 Section 08 (agents) cleanup - the largest section: versioned agents, code interpreter, hosted agents, agent memory, two MCP servers, offline evaluation, live observability, and human-in-the-loop.
@@ -123,6 +129,7 @@ Initial public release of the **Awesome Foundry Nextgen** lab series.
 - Contributor docs: [README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md),
   [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), [SECURITY.md](SECURITY.md).
 
+[0.5.1]: https://github.com/corticalstack/awesome-foundry-nextgen/releases/tag/v0.5.1
 [0.5.0]: https://github.com/corticalstack/awesome-foundry-nextgen/releases/tag/v0.5.0
 [0.4.0]: https://github.com/corticalstack/awesome-foundry-nextgen/releases/tag/v0.4.0
 [0.3.0]: https://github.com/corticalstack/awesome-foundry-nextgen/releases/tag/v0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awesome-foundry-nextgen"
-version = "0.5.0"
+version = "0.5.1"
 description = "Hands-on labs for Microsoft Foundry — Azure's unified PaaS for enterprise AI"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Single-line correctness fix plus version bump to **v0.5.1** (patch).

07-01 referenced the `.env` prerequisite as `04-foundry-project-pattern-setup`, but the project pattern setup is **section 05** (section 04 is the control plane) - the same copy-paste error that was corrected across section 08 in v0.5.0.

A word-boundary-guarded repo-wide audit confirmed this was the **only genuine** wrong-number cross-section reference. Earlier apparent matches were false positives: substrings of valid `NN-MM-slug` filenames (e.g. `09-foundry-control-plane` inside `04-09-foundry-control-plane-cheat-sheet.md`).

## Test plan

- [ ] `grep -rn '04-foundry-project-pattern-setup' --include='*.ipynb' --include='*.md' .` returns only the CHANGELOG entries describing the fix