### PR TITLE
docs(08): fix HITL notebook - rename, agent name, and refresh approval guidance

### DIFF
--- a/08-agents/08-00-what-is-an-agent.md
+++ b/08-agents/08-00-what-is-an-agent.md
@@ -75,7 +75,7 @@ The labs in this directory put these building blocks into practice - agent versi
 | [08-05b-contoso-private-banking-mcp/](08-05b-contoso-private-banking-mcp/) | Private-banking MCP server variant - [overview](08-05b-contoso-private-banking-mcp/08-05b-00-contoso-private-banking-mcp.md), agent setup and queries notebooks, plus the Functions MCP app |
 | [08-06-agent-offline-evaluation/](08-06-agent-offline-evaluation/) | Pre-release agent evaluation against a curated test set - [overview](08-06-agent-offline-evaluation/08-06-00-agent-offline-evaluation.md), quality + RAI + agent-specific + custom evaluators, plus a full batch `evaluate()` run with portal logging |
 | [08-07-agent-live-observability/](08-07-agent-live-observability/) | OpenTelemetry tracing, real-time observability, and continuous evaluation - [overview](08-07-agent-live-observability/08-07-00-agent-live-observability.md), [tracing](08-07-agent-live-observability/08-07-02-agent-tracing.md), [real-time observability](08-07-agent-live-observability/08-07-04-real-time-observability.md), plus observability and continuous-eval notebooks |
-| [08-08-human-in-the-loop/](08-08-human-in-the-loop/) | Human-in-the-loop pattern - [overview](08-08-human-in-the-loop/08-08-00-human-in-the-loop.md) and `hitl.ipynb` walkthrough for pausing an agent for approval before tool execution |
+| [08-08-human-in-the-loop/](08-08-human-in-the-loop/) | Human-in-the-loop pattern - [overview](08-08-human-in-the-loop/08-08-00-human-in-the-loop.md) and [08-08-01-human-in-the-loop.ipynb](08-08-human-in-the-loop/08-08-01-human-in-the-loop.ipynb) walkthrough for pausing an agent for approval before tool execution |
 
 ## Resources
 

--- a/08-agents/08-05b-contoso-private-banking-mcp/08-05b-02-private-banking-agent-queries.ipynb
+++ b/08-agents/08-05b-contoso-private-banking-mcp/08-05b-02-private-banking-agent-queries.ipynb
@@ -127,9 +127,7 @@
    "cell_type": "markdown",
    "id": "bc730248",
    "metadata": {},
-   "source": [
-    "Set up the `ask()` helper\\n\\nThe new-API invocation goes through the Responses surface - `openai_client.responses.create(..., extra_body={'agent_reference': ...})` - exactly the same pattern as [`08-08-human-in-the-loop/hitl.ipynb`](../08-08-human-in-the-loop/hitl.ipynb). MCP tool calls and their outputs appear inline in `response.output`."
-   ]
+   "source": "Set up the `ask()` helper\\n\\nThe new-API invocation goes through the Responses surface - `openai_client.responses.create(..., extra_body={'agent_reference': ...})` - exactly the same pattern as [`08-08-human-in-the-loop/08-08-01-human-in-the-loop.ipynb`](../08-08-human-in-the-loop/08-08-01-human-in-the-loop.ipynb). MCP tool calls and their outputs appear inline in `response.output`."
   },
   {
    "cell_type": "code",

--- a/08-agents/08-08-human-in-the-loop/08-08-00-human-in-the-loop.md
+++ b/08-agents/08-08-human-in-the-loop/08-08-00-human-in-the-loop.md
@@ -13,7 +13,7 @@ This lab demonstrates the **Human-in-the-Loop (HITL)** pattern: intercepting age
 5. [Tool routing](#5-tool-routing)
 6. [Approval and rejection flows](#6-approval-and-rejection-flows)
 7. [Multi-step scenarios](#7-multi-step-scenarios)
-8. [Future: MAF `approval_mode`](#8-future-maf-approval_mode)
+8. [Related patterns](#8-related-patterns)
 9. [Files in this lab](#9-files-in-this-lab)
 10. [Primary sources](#10-primary-sources)
 
@@ -54,7 +54,7 @@ For read-only or idempotent operations (balance checks, searches, lookups), auto
 
 ## 3. HITL approval loop
 
-The HITL pattern implemented in [`hitl.ipynb`](hitl.ipynb) follows this loop:
+The HITL pattern implemented in [`08-08-01-human-in-the-loop.ipynb`](08-08-01-human-in-the-loop.ipynb) follows this loop:
 
 ```
 responses.create(user_message)
@@ -89,14 +89,14 @@ The core Responses API calls used in the HITL loop:
 # Initial call - start a new agent turn
 response = openai_client.responses.create(
     input=[{"role": "user", "content": user_message}],
-    extra_body={"agent": {"name": agent.name, "type": "agent_reference"}},
+    extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
 )
 
 # Continuation call - submit tool results and get the next response
 response = openai_client.responses.create(
     input=tool_outputs,               # list of function_call_output dicts
     previous_response_id=response.id, # links this call to the previous turn
-    extra_body={"agent": {"name": agent.name, "type": "agent_reference"}},
+    extra_body={"agent_reference": {"name": agent.name, "type": "agent_reference"}},
 )
 ```
 
@@ -139,7 +139,7 @@ for call in tool_calls:
 - Policy is defined in the client, not the tool - multiple clients must each maintain consistent sets
 - No per-invocation context - the decision is based solely on the tool name, not the argument values
 
-See [Section 8](#8-future-maf-approval_mode) for the upcoming MAF `approval_mode` feature which moves the policy declaration to the tool definition itself.
+See [Section 8](#8-related-patterns) for how this manual routing relates to the MAF `@tool(approval_mode=...)` decorator (a different runtime layer) and the Foundry `MCPTool(require_approval=...)` server-side flag (MCP tools only).
 
 ---
 
@@ -181,7 +181,7 @@ The agent receives the rejection message and acknowledges that the action was no
 
 The HITL loop handles scenarios where a single user message triggers multiple tool calls, including a mix of auto-execute and approval-required tools.
 
-In the multi-step scenario in [`hitl.ipynb`](hitl.ipynb), the agent:
+In the multi-step scenario in [`08-08-01-human-in-the-loop.ipynb`](08-08-01-human-in-the-loop.ipynb), the agent:
 1. Calls `get_account_balance` - auto-executed, no prompt shown
 2. Then calls `transfer_funds` - HITL prompt appears
 
@@ -191,31 +191,38 @@ Both tool calls may be returned in the same `response.output` batch, or the agen
 
 ---
 
-## 8. Future: MAF `approval_mode`
+## 8. Related patterns
 
-The [Microsoft Agent Framework (MAF)](https://learn.microsoft.com/en-us/agent-framework/tutorials/agents/function-tools-approvals?pivots=programming-language-python) is developing a first-class declarative alternative to the `APPROVAL_REQUIRED_TOOLS` set convention.
+Three different "approval" layers exist across the stack. This lab uses the third one because the first two do not cover its scenario (custom `FunctionTool` on a Foundry-hosted versioned agent).
 
-The planned pattern uses an `approval_mode` parameter on the `@ai_function` decorator:
+### 8.1 MAF `@tool(approval_mode="always_require")` - client-side runtime approvals
+
+Released in `agent-framework-core` and available in the version this repo pins (`1.0.0rc6`). Applies when the agent runs in the local [Microsoft Agent Framework (MAF)](https://learn.microsoft.com/en-us/agent-framework/tutorials/agents/function-tools-approvals?pivots=programming-language-python) runtime (`Agent(client=OpenAIChatClient(), ...)`), **not** when calling a Foundry-hosted agent through the Responses API. The MAF runtime returns `user_input_requests` on the run result; the caller replies with a `Message` containing `req.create_response(True|False)` to resume.
 
 ```python
-from agent_framework import ai_function
+from typing import Annotated
+from agent_framework import tool
 
-# Executes automatically
-@ai_function
-def get_account_balance(account_id: str) -> str:
+@tool
+def get_account_balance(account_id: Annotated[str, "Account ID"]) -> str:
     ...
 
-# Requires human approval before execution
-@ai_function(approval_mode="always_require")
-def transfer_funds(from_account: str, to_account: str, amount: float) -> str:
+@tool(approval_mode="always_require")
+def transfer_funds(from_account: Annotated[str, "Source account ID"],
+                   to_account:   Annotated[str, "Destination account ID"],
+                   amount:       Annotated[float, "Amount in USD"]) -> str:
     ...
 ```
 
-When `approval_mode="always_require"` is set, the MAF SDK intercepts the tool call and surfaces it as a `user_input_request` in the agent response, rather than executing it. The calling code then handles the approval flow using `create_response(True/False)`.
+The decorator name is `@tool` (the `@ai_function` alias appears in some API reference pages but is not exported by the `rc6` package this repo pins).
 
-**Current status:** The `approval_mode` parameter is not yet available in the published pip package as of the time this lab was written. The `APPROVAL_REQUIRED_TOOLS` convention in this lab provides equivalent functionality using the current stable SDK.
+### 8.2 Foundry `MCPTool(require_approval="always")` - server-side MCP approvals
 
-Once `approval_mode` ships, it will be a more ergonomic replacement: the approval policy lives with the tool definition, not in the calling code, making it harder to accidentally omit.
+Native server-side approval routing on the Foundry Agent Service, but only for MCP tools. When approval is required the Responses API returns an `mcp_approval_request` output item; the client submits an `mcp_approval_response` to continue. See: [Connect to MCP Server Endpoints for agents](https://learn.microsoft.com/en-us/azure/foundry/agents/how-to/tools/model-context-protocol).
+
+### 8.3 Manual interception - what this lab does
+
+For custom `FunctionTool` definitions on a Foundry-hosted agent there is no first-class `require_approval` flag in the current SDK (`azure-ai-projects` rc6 `FunctionTool` exposes only `name` / `description` / `parameters` / `strict` / `type`). The `APPROVAL_REQUIRED_TOOLS` set + Responses API loop demonstrated in this lab is the canonical pattern for this scenario.
 
 ---
 
@@ -223,7 +230,7 @@ Once `approval_mode` ships, it will be a more ergonomic replacement: the approva
 
 | File | Purpose |
 |------|---------|
-| [`hitl.ipynb`](hitl.ipynb) | Lab notebook - configuration, tool definitions, HITL loop helper, and three scenarios: approve, reject, and multi-step |
+| [`08-08-01-human-in-the-loop.ipynb`](08-08-01-human-in-the-loop.ipynb) | Lab notebook - configuration, tool definitions, HITL loop helper, and three scenarios: approve, reject, and multi-step |
 
 ---
 
@@ -231,4 +238,5 @@ Once `approval_mode` ships, it will be a more ergonomic replacement: the approva
 
 - [azure-ai-projects SDK - FunctionTool and PromptAgentDefinition](https://pypi.org/project/azure-ai-projects/) - Python SDK for the Foundry Agent Service
 - [OpenAI Responses API - function calling](https://platform.openai.com/docs/guides/function-calling) - how function calls are returned as output items and how tool results are submitted via `previous_response_id`
-- [MAF Function Tools with Human-in-the-Loop Approvals](https://learn.microsoft.com/en-us/agent-framework/tutorials/agents/function-tools-approvals?pivots=programming-language-python) - upcoming `approval_mode` pattern in the Microsoft Agent Framework
+- [MAF Function Tools with Human-in-the-Loop Approvals](https://learn.microsoft.com/en-us/agent-framework/tutorials/agents/function-tools-approvals?pivots=programming-language-python) - `@tool(approval_mode="always_require")` pattern for MAF client-side runtime agents
+- [Connect to MCP Server Endpoints for agents](https://learn.microsoft.com/en-us/azure/foundry/agents/how-to/tools/model-context-protocol) - Foundry server-side `MCPTool(require_approval="always")` approval routing

--- a/08-agents/08-08-human-in-the-loop/08-08-01-human-in-the-loop.ipynb
+++ b/08-agents/08-08-human-in-the-loop/08-08-01-human-in-the-loop.ipynb
@@ -46,10 +46,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "08060003-0000-0000-0000-000000000003",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Endpoint  : https://aif-spoke-alpha-c2676f.services.ai.azure.com/api/projects/project-alpha-c2676f\n",
+      "Agent name: payments-approval-agent\n",
+      "Model     : core-alpha/gpt-4.1-mini\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import json\n",
@@ -60,7 +70,7 @@
     "from azure.ai.projects import AIProjectClient\n",
     "\n",
     "# ── Change this to rename your agent ─────────────────────────────────────────\n",
-    "AGENT_NAME = \"08-06-hitl-agent\"\n",
+    "AGENT_NAME = \"payments-approval-agent\"\n",
     "# ─────────────────────────────────────────────────────────────────────────────\n",
     "\n",
     "repo_root = Path(subprocess.run(\n",
@@ -101,10 +111,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "08060005-0000-0000-0000-000000000005",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tools defined: get_account_balance, transfer_funds\n",
+      "Approval-required tools: {'transfer_funds'}\n"
+     ]
+    }
+   ],
    "source": [
     "from azure.ai.projects.models import FunctionTool\n",
     "\n",
@@ -173,10 +192,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "08060007-0000-0000-0000-000000000007",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Agent created (id: payments-approval-agent:1, name: payments-approval-agent, version: 1)\n"
+     ]
+    }
+   ],
    "source": [
     "from azure.ai.projects.models import PromptAgentDefinition\n",
     "\n",
@@ -224,10 +251,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "08060009-0000-0000-0000-000000000009",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HITL helper defined - ready to run scenarios.\n"
+     ]
+    }
+   ],
    "source": [
     "def run_with_hitl(user_message: str) -> str:\n",
     "    \"\"\"Run the agent with HITL interception for approval-required tools.\n",
@@ -311,10 +346,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "08060011-0000-0000-0000-000000000011",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scenario: Approve a fund transfer\n",
+      "------------------------------------------------------------\n",
+      "\n",
+      "============================================================\n",
+      "[APPROVAL REQUIRED] Tool: transfer_funds\n",
+      "Arguments:\n",
+      "  from_account: ACC-001\n",
+      "  to_account: ACC-002\n",
+      "  amount: 500\n",
+      "============================================================\n",
+      "[REJECTED] transfer_funds will not execute\n",
+      "\n",
+      "============================================================\n",
+      "Agent response:\n",
+      "The transfer of $500 from ACC-001 to ACC-002 was not approved. Is there anything else you would like to do?\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Scenario: Approve a fund transfer\")\n",
     "print(\"-\" * 60)\n",
@@ -347,10 +404,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "08060013-0000-0000-0000-000000000013",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scenario: Reject a fund transfer\n",
+      "------------------------------------------------------------\n",
+      "\n",
+      "============================================================\n",
+      "[APPROVAL REQUIRED] Tool: transfer_funds\n",
+      "Arguments:\n",
+      "  from_account: ACC-002\n",
+      "  to_account: ACC-003\n",
+      "  amount: 10000\n",
+      "============================================================\n",
+      "[APPROVED] Executing transfer_funds -> Successfully transferred $10,000.00 from ACC-002 to ACC-003.\n",
+      "\n",
+      "============================================================\n",
+      "Agent response:\n",
+      "The transfer of $10,000 from ACC-002 to ACC-003 has been successfully completed. Is there anything else you would like to do?\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Scenario: Reject a fund transfer\")\n",
     "print(\"-\" * 60)\n",
@@ -384,10 +463,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "08060015-0000-0000-0000-000000000015",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scenario: Multi-step - balance check (auto) then transfer (approval)\n",
+      "------------------------------------------------------------\n",
+      "[AUTO-EXECUTE] get_account_balance({'account_id': 'ACC-001'}) -> Account ACC-001 balance: $5,000.00\n",
+      "\n",
+      "============================================================\n",
+      "[APPROVAL REQUIRED] Tool: transfer_funds\n",
+      "Arguments:\n",
+      "  from_account: ACC-001\n",
+      "  to_account: ACC-003\n",
+      "  amount: 200\n",
+      "============================================================\n",
+      "[APPROVED] Executing transfer_funds -> Successfully transferred $200.00 from ACC-001 to ACC-003.\n",
+      "\n",
+      "============================================================\n",
+      "Agent response:\n",
+      "The balance on account ACC-001 is $5,000. I have transferred $200 from ACC-001 to ACC-003.\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Scenario: Multi-step - balance check (auto) then transfer (approval)\")\n",
     "print(\"-\" * 60)\n",
@@ -405,64 +507,22 @@
    "cell_type": "markdown",
    "id": "08060016-0000-0000-0000-000000000016",
    "metadata": {},
-   "source": [
-    "## Summary\n",
-    "\n",
-    "### Key concepts\n",
-    "\n",
-    "| Concept | Description |\n",
-    "|---------|-------------|\n",
-    "| `APPROVAL_REQUIRED_TOOLS` | A set of tool names that trigger the human approval branch |\n",
-    "| `function_call` output item | The Responses API returns tool calls as output items - it does **not** execute them |\n",
-    "| `previous_response_id` | Continues the response loop when submitting tool results back to the agent |\n",
-    "| `function_call_output` | The message type used to submit tool execution results to the Responses API |\n",
-    "| `input()` for approval | Works in Jupyter notebooks; replace with webhook/UI event in production |\n",
-    "\n",
-    "### The HITL loop\n",
-    "\n",
-    "```\n",
-    "responses.create(user_message)\n",
-    "    |\n",
-    "    v\n",
-    "response.output contains function_call items?\n",
-    "    |\n",
-    "    +-- No  --> return response.output_text\n",
-    "    |\n",
-    "    +-- Yes --> for each tool_call:\n",
-    "                    if name in APPROVAL_REQUIRED_TOOLS:\n",
-    "                        prompt operator --> approve/reject\n",
-    "                    else:\n",
-    "                        auto-execute\n",
-    "                responses.create(tool_outputs, previous_response_id=response.id)\n",
-    "                loop back ^\n",
-    "```\n",
-    "\n",
-    "### Future: MAF `approval_mode`\n",
-    "\n",
-    "The [Microsoft Agent Framework (MAF)](https://learn.microsoft.com/en-us/agent-framework/tutorials/agents/function-tools-approvals?pivots=programming-language-python) is developing a first-class `approval_mode` parameter for `@ai_function` decorators:\n",
-    "\n",
-    "```python\n",
-    "# Future MAF pattern (not yet available in published pip package)\n",
-    "from agent_framework import ai_function\n",
-    "\n",
-    "@ai_function(approval_mode=\"always_require\")\n",
-    "def transfer_funds(from_account: str, to_account: str, amount: float) -> str:\n",
-    "    ...\n",
-    "```\n",
-    "\n",
-    "This will provide a more ergonomic, declarative alternative to the `APPROVAL_REQUIRED_TOOLS` convention used in this lab. The underlying interception mechanism is the same - the SDK will handle the routing automatically. Once `approval_mode` ships in a stable release, it can replace the manual routing in this notebook.\n",
-    "\n",
-    "### Cleanup reminder\n",
-    "\n",
-    "Run the cleanup cell below to delete the versioned agent when you are done with this lab."
-   ]
+   "source": "## Summary\n\n### Key concepts\n\n| Concept | Description |\n|---------|-------------|\n| `APPROVAL_REQUIRED_TOOLS` | A set of tool names that trigger the human approval branch |\n| `function_call` output item | The Responses API returns tool calls as output items - it does **not** execute them |\n| `previous_response_id` | Continues the response loop when submitting tool results back to the agent |\n| `function_call_output` | The message type used to submit tool execution results to the Responses API |\n| `input()` for approval | Works in Jupyter notebooks; replace with webhook/UI event in production |\n\n### The HITL loop\n\n```\nresponses.create(user_message)\n    |\n    v\nresponse.output contains function_call items?\n    |\n    +-- No  --> return response.output_text\n    |\n    +-- Yes --> for each tool_call:\n                    if name in APPROVAL_REQUIRED_TOOLS:\n                        prompt operator --> approve/reject\n                    else:\n                        auto-execute\n                responses.create(tool_outputs, previous_response_id=response.id)\n                loop back ^\n```\n\n### Related patterns\n\nThree different \"approval\" layers exist across the stack. This notebook uses the third one because the first two do not cover its scenario (custom `FunctionTool` on a Foundry-hosted versioned agent).\n\n**1. MAF `@tool(approval_mode=\"always_require\")`** - client-side runtime approvals\n\nReleased in `agent-framework-core` and available in the version this repo pins (`1.0.0rc6`). Applies when the agent runs in the local MAF runtime (`Agent(client=OpenAIChatClient(), ...)`), **not** when calling a Foundry-hosted agent through the Responses API. The MAF runtime returns `user_input_requests` on the run result; the caller replies with `Message(role=\"user\", contents=[req.create_response(True|False)])` to resume.\n\n```python\nfrom typing import Annotated\nfrom agent_framework import tool\n\n@tool(approval_mode=\"always_require\")\ndef transfer_funds(from_account: Annotated[str, \"Source account ID\"],\n                   to_account:   Annotated[str, \"Destination account ID\"],\n                   amount:       Annotated[float, \"Amount in USD\"]) -> str:\n    return f\"Transferred ${amount:,.2f} from {from_account} to {to_account}.\"\n```\n\nSee: [Using function tools with human in the loop approvals](https://learn.microsoft.com/en-us/agent-framework/tutorials/agents/function-tools-approvals?pivots=programming-language-python).\n\n**2. Foundry `MCPTool(require_approval=\"always\")`** - server-side MCP approvals\n\nNative server-side approval routing on the Foundry Agent Service, but only for MCP tools. When approval is required the Responses API returns an `mcp_approval_request` output item; the client submits an `mcp_approval_response` to continue. See: [Connect to MCP Server Endpoints for agents](https://learn.microsoft.com/en-us/azure/foundry/agents/how-to/tools/model-context-protocol).\n\n**3. Manual interception** - what this notebook does\n\nFor custom `FunctionTool` definitions on a Foundry-hosted agent there is no first-class `require_approval` flag in the current SDK (`azure-ai-projects` rc6 `FunctionTool` exposes only `name` / `description` / `parameters` / `strict` / `type`). The `APPROVAL_REQUIRED_TOOLS` set + Responses API loop shown above is the canonical pattern for this scenario.\n\n### Cleanup reminder\n\nRun the cleanup cell below to delete the versioned agent when you are done with this lab."
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "08060017-0000-0000-0000-000000000017",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleted agent version 1 of 'payments-approval-agent'.\n"
+     ]
+    }
+   ],
    "source": [
     "# Cleanup - delete the versioned agent\n",
     "project_client.agents.delete_version(agent_name=agent.name, agent_version=agent.version)\n",
@@ -472,13 +532,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "awesome-foundry-nextgen",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-05-27
+
+Section 08 HITL lab cleanup: notebook rename, agent rename, and corrected guidance on MAF / Foundry approval mechanisms.
+
+### Changed
+
+- Renamed `08-agents/08-08-human-in-the-loop/hitl.ipynb` to `08-08-01-human-in-the-loop.ipynb` to match the `NN-MM-NN-slug` convention used by sibling sub-folders. Updated inbound references in `08-agents/08-00-what-is-an-agent.md` and the cross-reference in `08-agents/08-05b-contoso-private-banking-mcp/08-05b-02-private-banking-agent-queries.ipynb`.
+- Renamed the demo agent from `08-06-hitl-agent` (wrong chapter prefix) to `payments-approval-agent`, matching the descriptive `{domain}-{role}-agent` naming used elsewhere in section 08.
+- Replaced the "Future: MAF `approval_mode`" section in both the notebook and the overview with a "Related patterns" section that explains the three approval layers (MAF `@tool(approval_mode=...)`, Foundry `MCPTool(require_approval=...)`, manual interception) and when each applies.
+
+### Fixed
+
+- The MAF `approval_mode` guidance said "is developing" / "not yet available in published pip package". The feature has shipped in `agent-framework-core==1.0.0rc6` (the version this repo pins) and the decorator name in that release is `@tool`, not `@ai_function`. Text updated to reflect released status and corrected decorator name.
+- The `extra_body` code sample in section 4 of the overview used the wrong key (`agent` instead of `agent_reference`), which would have failed if copy-pasted. Fixed both occurrences to match the working pattern in the notebook.
+
 ## [0.8.0] - 2026-05-22
 
 Sections 13 (guardrails), 14 (red teaming), and 15 (fine-tuning) cleanup. This completes the systematic documentation pass over every section (00-15).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awesome-foundry-nextgen"
-version = "0.8.0"
+version = "0.8.1"
 description = "Hands-on labs for Microsoft Foundry — Azure's unified PaaS for enterprise AI"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Section 08 HITL lab cleanup. Three things:

- **Rename** `hitl.ipynb` → `08-08-01-human-in-the-loop.ipynb` to match the `NN-MM-NN-slug` convention used by sibling sub-folders. Inbound references updated in `08-00-what-is-an-agent.md` and the cross-reference in `08-05b-02-private-banking-agent-queries.ipynb`.
- **Agent rename** in the notebook: `08-06-hitl-agent` (wrong chapter prefix, undescriptive) → `payments-approval-agent`, matching `{domain}-{role}-agent` naming used elsewhere in section 08.
- **Refreshed MAF guidance.** The "Future: MAF `approval_mode`" section said the feature was "in development" / "not yet available in published pip package". It has shipped in `agent-framework-core==1.0.0rc6` (the version this repo pins), and the decorator name in that release is `@tool`, not `@ai_function`. Replaced with a "Related patterns" section that scopes the three approval layers:
  - MAF `@tool(approval_mode="always_require")` - client-side runtime agents (released)
  - Foundry `MCPTool(require_approval="always")` - server-side, MCP tools only
  - Manual interception via `APPROVAL_REQUIRED_TOOLS` - what this lab actually does (canonical for custom `FunctionTool` on a Foundry-hosted agent)

Also fixes a wrong `extra_body` key in the overview's section 4 code samples (`agent` → `agent_reference`) that would have failed if copy-pasted.

No pyproject pin bump needed; `agent-framework-core==1.0.0rc6` already exposes `@tool(approval_mode=...)`, and the existing pin is still required for `azure-ai-projects` compatibility.

Patch release 0.8.1.

## Test plan

- [ ] `08-08-01-human-in-the-loop.ipynb` runs end-to-end and creates an agent named `payments-approval-agent`
- [ ] Cross-references in `08-00-what-is-an-agent.md` and `08-05b-02-private-banking-agent-queries.ipynb` resolve
- [ ] Section 4 `extra_body` example in the overview matches the working notebook (`agent_reference` key)