### PR TITLE
fix(05,12): raise o3-deep-research TPM capacity from 10 to 200

### DIFF
--- a/05-foundry-project-pattern-setup/05-02-deploy-foundry-core-gateway/main.bicep
+++ b/05-foundry-project-pattern-setup/05-02-deploy-foundry-core-gateway/main.bicep
@@ -120,7 +120,10 @@ resource researchHub 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' =
 resource researchModel 'Microsoft.CognitiveServices/accounts/deployments@2025-04-01-preview' = {
   parent: researchHub
   name: 'o3-deep-research'
-  sku: { name: 'GlobalStandard', capacity: 10 }
+  // Capacity is K-TPM. 10 was too low - multi-step deep-research runs hit
+  // 429 throttling before completing. 200 gives realistic headroom while
+  // staying well under the Norway East o3-DeepResearch subscription quota.
+  sku: { name: 'GlobalStandard', capacity: 200 }
   properties: {
     model: {
       name: 'o3-deep-research'

--- a/12-foundry-iq-deep-research/main.bicep
+++ b/12-foundry-iq-deep-research/main.bicep
@@ -54,7 +54,10 @@ resource researchHub 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' =
 resource researchModel 'Microsoft.CognitiveServices/accounts/deployments@2025-04-01-preview' = {
   parent: researchHub
   name: 'o3-deep-research'
-  sku: { name: 'GlobalStandard', capacity: 10 }
+  // Capacity is K-TPM. 10 was too low - multi-step deep-research runs hit
+  // 429 throttling before completing. 200 gives realistic headroom while
+  // staying well under the Norway East o3-DeepResearch subscription quota.
+  sku: { name: 'GlobalStandard', capacity: 200 }
   properties: {
     model: {
       name: 'o3-deep-research'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.5] - 2026-05-27
+
+### Fixed
+
+- Raised the `o3-deep-research` model deployment capacity from 10 (10K TPM) to 200 (200K TPM) in both `05-foundry-project-pattern-setup/05-02-deploy-foundry-core-gateway/main.bicep` and `12-foundry-iq-deep-research/main.bicep`. The original 10K cap throttled multi-step deep-research runs with 429 errors before completion. 200K stays well under the Norway East `o3-DeepResearch` subscription quota (3000). Existing live deployments must be updated separately (`az cognitiveservices account deployment update --sku-capacity 200`) or via a fresh Bicep apply.
+
 ## [0.8.4] - 2026-05-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awesome-foundry-nextgen"
-version = "0.8.4"
+version = "0.8.5"
 description = "Hands-on labs for Microsoft Foundry — Azure's unified PaaS for enterprise AI"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Raise the `o3-deep-research` model deployment SKU capacity from `10` (10K TPM) to `200` (200K TPM) in both Bicep files that define it:

- `05-foundry-project-pattern-setup/05-02-deploy-foundry-core-gateway/main.bicep` (the hub deploy)
- `12-foundry-iq-deep-research/main.bicep` (the optional standalone deploy)

The original 10K cap throttles multi-step deep-research runs with 429 errors before they complete. 200K gives realistic headroom for the agentic deep-research loop while staying well under the Norway East `o3-DeepResearch` subscription quota (limit 3000 - confirmed via `az cognitiveservices usage list -l norwayeast`).

GlobalStandard billing is pay-per-token, so raising the capacity ceiling does not change baseline cost; it only raises the rate-limit cap.

## Existing deployments

Bumping the Bicep value does not update already-deployed resources. To update a live deployment in place without redeploying the whole template:

```bash
az cognitiveservices account deployment update \
  -g rg-foundry-core-{suffix} \
  -n aif-research-{suffix} \
  --deployment-name o3-deep-research \
  --sku-capacity 200
```

Patch release 0.8.5.

## Stacking note

This PR is stacked on `fix/deep-research-apim-key-lookup` (PR #12). Base set to that branch so the diff shows only the Bicep + version-bump changes. Merge #12 first, then this PR.

## Test plan

- [x] Fresh `az deployment group create` of either Bicep produces an `o3-deep-research` deployment with `sku.capacity = 200`
- [x] `12-02-deep-research-loop.ipynb` completes a multi-step research run without 429s
- [x] `az cognitiveservices usage list -l norwayeast` still shows the `OpenAI.GlobalStandard.o3-DeepResearch` total well under its limit