### PR TITLE
docs(09,10,13): normalise stale deployment suffix; placeholder in 13-00 prose

### DIFF
--- a/09-content-understanding-integration/09-01-deploy-setup.ipynb
+++ b/09-content-understanding-integration/09-01-deploy-setup.ipynb
@@ -64,7 +64,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Gateway URL   : https://apim-foundry-6fe574.azure-api.net/openai\n",
+      "Gateway URL   : https://apim-foundry-c2676f.azure-api.net/openai\n",
       "Chat model    : gpt-4.1-mini\n",
       "Bootstrap key : a9fe... (hidden)\n",
       "Prerequisites: OK\n"
@@ -132,10 +132,10 @@
      "output_type": "stream",
      "text": [
       "Subscription  : 00000000-0000-0000-0000-000000000000\n",
-      "APIM name     : apim-foundry-6fe574\n",
-      "Suffix        : 6fe574\n",
-      "Core RG        : rg-foundry-core-6fe574\n",
-      "CU RG         : rg-foundry-cu-6fe574\n",
+      "APIM name     : apim-foundry-c2676f\n",
+      "Suffix        : c2676f\n",
+      "Core RG        : rg-foundry-core-c2676f\n",
+      "CU RG         : rg-foundry-cu-c2676f\n",
       "Principal ID  : 00000000-0000-0000-0000-000000000000\n",
       "APIM MI       : 00000000-0000-0000-0000-000000000000\n"
      ]
@@ -201,10 +201,10 @@
      "output_type": "stream",
      "text": [
       "Hub location: eastus2\n",
-      "Resource group ready: rg-foundry-cu-6fe574\n",
+      "Resource group ready: rg-foundry-cu-c2676f\n",
       "Name     State      Timestamp                         Mode         ResourceGroup\n",
       "-------  ---------  --------------------------------  -----------  --------------------\n",
-      "cu-main  Succeeded  2026-03-09T19:38:28.767795+00:00  Incremental  rg-foundry-cu-6fe574\n",
+      "cu-main  Succeeded  2026-03-09T19:38:28.767795+00:00  Incremental  rg-foundry-cu-c2676f\n",
       "\n"
      ]
     }
@@ -335,11 +335,11 @@
      "text": [
       "Name    State      Timestamp                         Mode         ResourceGroup\n",
       "------  ---------  --------------------------------  -----------  ---------------------\n",
-      "cu-api  Succeeded  2026-03-09T19:44:10.780590+00:00  Incremental  rg-foundry-core-6fe574\n",
+      "cu-api  Succeeded  2026-03-09T19:44:10.780590+00:00  Incremental  rg-foundry-core-c2676f\n",
       "\n",
       "Name     State      Timestamp                         Mode         ResourceGroup\n",
       "-------  ---------  --------------------------------  -----------  --------------------\n",
-      "cu-rbac  Succeeded  2026-03-09T19:44:53.148068+00:00  Incremental  rg-foundry-cu-6fe574\n",
+      "cu-rbac  Succeeded  2026-03-09T19:44:53.148068+00:00  Incremental  rg-foundry-cu-c2676f\n",
       "\n"
      ]
     }
@@ -626,10 +626,10 @@
      "text": [
       "Project   : https://aif-cu-ii5drx.services.ai.azure.com/api/projects/cu-project\n",
       "Connections:\n",
-      "  landing-zone-apim (ApiManagement) -> https://apim-foundry-6fe574.azure-api.net/openai\n",
+      "  landing-zone-apim (ApiManagement) -> https://apim-foundry-c2676f.azure-api.net/openai\n",
       "\n",
       "Deployment summary:\n",
-      "  CU_RESOURCE_GROUP           : rg-foundry-cu-6fe574\n",
+      "  CU_RESOURCE_GROUP           : rg-foundry-cu-c2676f\n",
       "  CU_FOUNDRY_PROJECT_ENDPOINT : https://aif-cu-ii5drx.services.ai.azure.com/api/projects/cu-project\n",
       "  CU_GATEWAY_KEY              : 016ab9c4...\n",
       "Verification: OK\n"

--- a/09-content-understanding-integration/09-02-cu-analyze.ipynb
+++ b/09-content-understanding-integration/09-02-cu-analyze.ipynb
@@ -62,7 +62,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CU gateway URL   : https://apim-foundry-6fe574.azure-api.net/cu\n",
+      "CU gateway URL   : https://apim-foundry-c2676f.azure-api.net/cu\n",
       "CU API version   : 2025-11-01\n",
       "APIM connection  : landing-zone-apim\n",
       "Gateway key      : 016a... (hidden)\n"
@@ -194,7 +194,7 @@
       "Analysis submitted (202 Accepted)\n",
       "Operation-Location: https://aif-cu-ii5drx.cognitiveservices.azure.com/contentunderstanding/analyzerR...\n",
       "\n",
-      "Rewritten poll URL : https://apim-foundry-6fe574.azure-api.net/cu/analyzerResults/4cd6d816-a83d-43e5-...\n"
+      "Rewritten poll URL : https://apim-foundry-c2676f.azure-api.net/cu/analyzerResults/4cd6d816-a83d-43e5-...\n"
      ]
     }
    ],

--- a/10-foundry-iq/10-03-knowledge-base-setup.ipynb
+++ b/10-foundry-iq/10-03-knowledge-base-setup.ipynb
@@ -78,12 +78,12 @@
       "Project endpoint : https://aif-spoke-multi-gvwiex.services.ai.azure.com/api/projects/iq-project\n",
       "Account name     : aif-spoke-multi-gvwiex\n",
       "Project name     : iq-project\n",
-      "APIM base        : https://apim-foundry-6fe574.azure-api.net\n",
+      "APIM base        : https://apim-foundry-c2676f.azure-api.net\n",
       "Agent model      : iq-apim-connection/gpt-4.1-mini\n",
       "MCP endpoint     : https://iq-search-gvwiex.search.windows.net/knowledgebases/arxiv-nlp-kb/mcp?api-version=2025-11-01-Preview\n",
       "MCP endpoint fast: https://iq-search-gvwiex.search.windows.net/knowledgebases/arxiv-nlp-kb-fast/mcp?api-version=2025-11-01-Preview\n",
       "Subscription     : 00000000-0000-0000-0000-000000000000\n",
-      "Resource group   : rg-foundry-multi-6fe574\n"
+      "Resource group   : rg-foundry-multi-c2676f\n"
      ]
     }
    ],

--- a/13-guardrails/13-00-guardrails.md
+++ b/13-guardrails/13-00-guardrails.md
@@ -69,7 +69,7 @@ Three notebooks plus this guide. Run them in sequence the first time; on repeat 
 
 If any of the SDK calls in `13-01` fail (typically because the calling identity lacks
 `Cognitive Services Contributor` on the Foundry account), do the same three things from
-the Azure portal under `aif-core-6fe574`:
+the Azure portal under `aif-core-{suffix}`:
 
 1. **Content filters → + Custom blocklist** - name `bank-demo-blocklist`. Add the entries
    listed in cell 4 of [13-01](13-01-configure-bank-guardrails.ipynb); flip the *regex*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.7] - 2026-05-27
+
+### Fixed
+
+- `13-guardrails/13-00-guardrails.md` portal-fallback section referenced a hard-coded resource name `aif-core-6fe574`. Users following the doc against their own deployment will have a different suffix. Replaced with `aif-core-{suffix}` to match the placeholder convention used everywhere else in prose.
+
+### Changed
+
+- Normalised a stale older deployment suffix `6fe574` to the current canonical demonstration suffix `c2676f` across cached notebook outputs in `09-content-understanding-integration/09-01-deploy-setup.ipynb` (11 occurrences), `09-content-understanding-integration/09-02-cu-analyze.ipynb` (2), and `10-foundry-iq/10-03-knowledge-base-setup.ipynb` (2). The two suffixes co-existed in different files because the cached outputs were captured from two different deployment generations; readers now see a single consistent suffix.
+
 ## [0.8.6] - 2026-05-27
 
 Tenant-identifier scrub of cached notebook outputs across sections 08 and 12, plus refreshed cached outputs for the deep-research notebooks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awesome-foundry-nextgen"
-version = "0.8.6"
+version = "0.8.7"
 description = "Hands-on labs for Microsoft Foundry — Azure's unified PaaS for enterprise AI"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Two related fixes:

### 1. `13-00-guardrails.md` portal fallback (the bug)

Section "Portal fallback" referenced a hard-coded `aif-core-6fe574` as the resource to open in the Azure portal. That's the author's deployment suffix - users following the doc against their own deployment have a different suffix, so the instruction was misleading. Replaced with `aif-core-{suffix}` to match the placeholder convention used everywhere else in prose.

### 2. Normalised stale `6fe574` suffix in 3 notebook cached outputs

While scanning for the bug above, found `6fe574` (a stale suffix from an earlier deployment generation) lingering in cached cell outputs across three notebooks. Those outputs were captured before the current `c2676f` demonstration suffix became canonical, so readers see two different suffixes depending on which notebook they're in:

- `09-content-understanding-integration/09-01-deploy-setup.ipynb` (11 occurrences)
- `09-content-understanding-integration/09-02-cu-analyze.ipynb` (2)
- `10-foundry-iq/10-03-knowledge-base-setup.ipynb` (2)

Normalised all 15 to `c2676f` so the demonstration suffix is consistent across the repo. Per the repo's hygiene policy (per 0.3.0 / 0.5.0 changelog entries), deterministic suffixes in cached outputs are kept rather than placeholder'd - this PR keeps with that policy, just makes the kept value consistent.

## Test plan

- [x] `grep -r 6fe574 --include='*.md' --include='*.ipynb'` returns nothing across the repo
- [x] All four touched files (1 markdown + 3 notebooks) open cleanly
- [x] 13-00 portal-fallback section now reads `aif-core-{suffix}`

Patch release 0.8.7.